### PR TITLE
Add support for multiple secret managers

### DIFF
--- a/configs/runner.yaml
+++ b/configs/runner.yaml
@@ -1,5 +1,13 @@
 runner:
   mode: orchestrated                  # orchestrated | oneshot
+  
+  # Secrets management configuration (optional)
+  # Defaults to environment variables if not specified
+  # See docs/SECRETS_MANAGEMENT.md for detailed configuration options
+  # secrets:
+  #   type: env                       # env (default), filesystem, vault, aws, gcp, azure
+  #   prefix: DATIVO_                 # Optional: prefix for env vars or secret names
+  
   orchestrator:
     type: dagster
     schedules:

--- a/docs/SECRETS_MANAGEMENT.md
+++ b/docs/SECRETS_MANAGEMENT.md
@@ -1,0 +1,612 @@
+# Secrets Management
+
+Dativo supports multiple secret management backends to securely store and retrieve credentials for your data connectors. You can choose the secret manager that best fits your infrastructure and security requirements.
+
+## Supported Secret Managers
+
+- **Environment Variables** (default) - Simple and works everywhere
+- **Filesystem** - File-based secrets storage (legacy default)
+- **HashiCorp Vault** - Enterprise secret management
+- **AWS Secrets Manager** - AWS-native secret storage
+- **Google Cloud Secret Manager** - GCP-native secret storage
+- **Azure Key Vault** - Azure-native secret storage
+
+## Configuration
+
+Secret manager configuration is specified in the `secrets` section of your `runner.yaml` file:
+
+```yaml
+runner:
+  mode: orchestrated
+  orchestrator:
+    type: dagster
+    schedules:
+      - name: my_job
+        config: /app/jobs/my_job.yaml
+        cron: "0 * * * *"
+  
+  # Secrets configuration
+  secrets:
+    type: env  # or filesystem, vault, aws, gcp, azure
+    # ... type-specific options ...
+```
+
+If the `secrets` section is omitted, the default behavior is to use environment variables.
+
+## 1. Environment Variables (Default)
+
+The simplest option - secrets are loaded from environment variables. This is the **default** if no secrets configuration is provided.
+
+### Configuration
+
+```yaml
+runner:
+  # ... orchestrator config ...
+  secrets:
+    type: env
+    prefix: DATIVO_  # Optional: prefix for environment variables
+```
+
+### Usage
+
+Set environment variables with the pattern: `{PREFIX}{TENANT_ID}_{SECRET_NAME}` or `{PREFIX}{SECRET_NAME}`
+
+```bash
+# Tenant-specific secrets
+export DATIVO_ACME_STRIPE_API_KEY="sk_live_..."
+export DATIVO_ACME_DATABASE_PASSWORD="secret123"
+
+# Global secrets (used if tenant-specific not found)
+export DATIVO_NESSIE_URI="http://nessie:19120/api/v1"
+export DATIVO_S3_ENDPOINT="http://minio:9000"
+```
+
+### Minimal Configuration
+
+```yaml
+# No secrets section needed - environment variables are the default
+runner:
+  mode: orchestrated
+  orchestrator:
+    type: dagster
+    schedules:
+      - name: stripe_sync
+        config: /app/jobs/stripe.yaml
+        cron: "0 * * * *"
+```
+
+## 2. Filesystem
+
+File-based secrets storage (original implementation). Secrets are stored in files organized by tenant.
+
+### Configuration
+
+```yaml
+runner:
+  # ... orchestrator config ...
+  secrets:
+    type: filesystem
+    secrets_dir: /secrets  # Default: /secrets
+```
+
+### Directory Structure
+
+```
+/secrets/
+  acme/
+    stripe.json         # JSON secret
+    postgres.env        # Environment file
+    api_key.txt         # Plain text secret
+  globex/
+    hubspot.json
+    mysql.env
+```
+
+### Secret Files
+
+**JSON format** (`.json`):
+```json
+{
+  "api_key": "sk_live_...",
+  "webhook_secret": "whsec_..."
+}
+```
+
+**Environment format** (`.env`):
+```
+DB_HOST=postgres.example.com
+DB_PORT=5432
+DB_USER=readonly
+DB_PASSWORD=secret123
+```
+
+**Plain text** (`.txt`, `.key`, etc):
+```
+sk_live_51234567890abcdef...
+```
+
+## 3. HashiCorp Vault
+
+Enterprise-grade secret management with encryption, audit logging, and fine-grained access control.
+
+### Configuration
+
+```yaml
+runner:
+  # ... orchestrator config ...
+  secrets:
+    type: vault
+    url: https://vault.example.com:8200
+    token: ${VAULT_TOKEN}  # Can also be set via VAULT_TOKEN env var
+    mount_point: secret  # KV secrets engine mount point (default: secret)
+    namespace: my-namespace  # Optional: Vault namespace
+    verify: true  # Verify SSL certificates (default: true)
+```
+
+### Vault Secret Structure
+
+Secrets are stored at path: `{mount_point}/data/{tenant_id}`
+
+```bash
+# Write secrets for tenant 'acme'
+vault kv put secret/acme \
+  stripe_api_key="sk_live_..." \
+  database_password="secret123" \
+  hubspot_api_key="pat-na1-..."
+
+# Read secrets
+vault kv get secret/acme
+```
+
+### Authentication
+
+You can provide the Vault token in three ways:
+1. In the configuration: `token: s.AbCdEf123456...`
+2. Environment variable: `export VAULT_TOKEN=s.AbCdEf123456...`
+3. Vault agent (automatic authentication)
+
+### Example
+
+```yaml
+runner:
+  mode: orchestrated
+  orchestrator:
+    type: dagster
+    schedules:
+      - name: stripe_sync
+        config: /app/jobs/stripe.yaml
+        cron: "0 * * * *"
+  
+  secrets:
+    type: vault
+    url: https://vault.prod.example.com:8200
+    mount_point: dativo
+    namespace: engineering
+```
+
+## 4. AWS Secrets Manager
+
+AWS-native secret storage with encryption, rotation, and IAM-based access control.
+
+### Configuration
+
+```yaml
+runner:
+  # ... orchestrator config ...
+  secrets:
+    type: aws
+    region_name: us-east-1  # Optional: defaults to AWS config
+    prefix: dativo/  # Optional: prefix for secret names
+```
+
+### Secret Structure
+
+**Option 1: Single secret per tenant** (recommended)
+
+Create a secret named `{prefix}{tenant_id}` with JSON value:
+
+```bash
+# AWS CLI
+aws secretsmanager create-secret \
+  --name dativo/acme \
+  --secret-string '{
+    "stripe_api_key": "sk_live_...",
+    "database_password": "secret123",
+    "hubspot_api_key": "pat-na1-..."
+  }' \
+  --region us-east-1
+```
+
+**Option 2: Multiple secrets per tenant**
+
+Create secrets with pattern `{prefix}{tenant_id}/{secret_name}`:
+
+```bash
+# AWS CLI
+aws secretsmanager create-secret \
+  --name dativo/acme/stripe_api_key \
+  --secret-string 'sk_live_...' \
+  --region us-east-1
+
+aws secretsmanager create-secret \
+  --name dativo/acme/database_password \
+  --secret-string 'secret123' \
+  --region us-east-1
+```
+
+### IAM Permissions
+
+The application needs these IAM permissions:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "secretsmanager:GetSecretValue",
+        "secretsmanager:ListSecrets"
+      ],
+      "Resource": "arn:aws:secretsmanager:us-east-1:123456789012:secret:dativo/*"
+    }
+  ]
+}
+```
+
+### Example
+
+```yaml
+runner:
+  mode: orchestrated
+  orchestrator:
+    type: dagster
+    schedules:
+      - name: stripe_sync
+        config: /app/jobs/stripe.yaml
+        cron: "0 * * * *"
+  
+  secrets:
+    type: aws
+    region_name: us-east-1
+    prefix: dativo/production/
+```
+
+## 5. Google Cloud Secret Manager
+
+GCP-native secret storage with encryption, versioning, and IAM-based access control.
+
+### Configuration
+
+```yaml
+runner:
+  # ... orchestrator config ...
+  secrets:
+    type: gcp
+    project_id: my-project-123  # Can also be set via GCP_PROJECT_ID env var
+    prefix: dativo-  # Optional: prefix for secret names
+```
+
+### Secret Structure
+
+**Option 1: Single secret per tenant** (recommended)
+
+Create a secret named `{prefix}{tenant_id}` with JSON value:
+
+```bash
+# gcloud CLI
+echo '{
+  "stripe_api_key": "sk_live_...",
+  "database_password": "secret123",
+  "hubspot_api_key": "pat-na1-..."
+}' | gcloud secrets create dativo-acme \
+  --data-file=- \
+  --project=my-project-123
+```
+
+**Option 2: Multiple secrets per tenant**
+
+Create secrets with pattern `{prefix}{tenant_id}-{secret_name}`:
+
+```bash
+# gcloud CLI
+echo 'sk_live_...' | gcloud secrets create dativo-acme-stripe-api-key \
+  --data-file=- \
+  --project=my-project-123
+
+echo 'secret123' | gcloud secrets create dativo-acme-database-password \
+  --data-file=- \
+  --project=my-project-123
+```
+
+### IAM Permissions
+
+The service account needs the Secret Manager Secret Accessor role:
+
+```bash
+gcloud projects add-iam-policy-binding my-project-123 \
+  --member="serviceAccount:dativo@my-project-123.iam.gserviceaccount.com" \
+  --role="roles/secretmanager.secretAccessor"
+```
+
+### Authentication
+
+Use Application Default Credentials (ADC):
+
+```bash
+# For development (uses your user account)
+gcloud auth application-default login
+
+# For production (uses service account)
+export GOOGLE_APPLICATION_CREDENTIALS=/path/to/service-account-key.json
+```
+
+### Example
+
+```yaml
+runner:
+  mode: orchestrated
+  orchestrator:
+    type: dagster
+    schedules:
+      - name: stripe_sync
+        config: /app/jobs/stripe.yaml
+        cron: "0 * * * *"
+  
+  secrets:
+    type: gcp
+    project_id: my-production-project
+    prefix: dativo-prod-
+```
+
+## 6. Azure Key Vault
+
+Azure-native secret storage with encryption, versioning, and Azure AD-based access control.
+
+### Configuration
+
+```yaml
+runner:
+  # ... orchestrator config ...
+  secrets:
+    type: azure
+    vault_url: https://my-vault.vault.azure.net/
+    prefix: dativo-  # Optional: prefix for secret names
+```
+
+### Secret Structure
+
+Create secrets with pattern `{prefix}{tenant_id}-{secret_name}`:
+
+**Note**: Azure Key Vault secret names can only contain alphanumeric characters and hyphens.
+
+```bash
+# Azure CLI
+az keyvault secret set \
+  --vault-name my-vault \
+  --name dativo-acme-stripe-api-key \
+  --value 'sk_live_...'
+
+az keyvault secret set \
+  --vault-name my-vault \
+  --name dativo-acme-database-password \
+  --value 'secret123'
+
+az keyvault secret set \
+  --vault-name my-vault \
+  --name dativo-acme-hubspot-api-key \
+  --value 'pat-na1-...'
+```
+
+### Access Policy
+
+Grant the application access to read secrets:
+
+```bash
+# Using service principal
+az keyvault set-policy \
+  --name my-vault \
+  --spn <service-principal-id> \
+  --secret-permissions get list
+
+# Using managed identity
+az keyvault set-policy \
+  --name my-vault \
+  --object-id <managed-identity-object-id> \
+  --secret-permissions get list
+```
+
+### Authentication
+
+The application uses DefaultAzureCredential which tries multiple authentication methods:
+1. Environment variables (AZURE_CLIENT_ID, AZURE_CLIENT_SECRET, AZURE_TENANT_ID)
+2. Managed identity (when running in Azure)
+3. Azure CLI credentials (for local development)
+
+```bash
+# For local development
+az login
+
+# For production (using service principal via environment variables)
+export AZURE_CLIENT_ID=<client-id>
+export AZURE_CLIENT_SECRET=<client-secret>
+export AZURE_TENANT_ID=<tenant-id>
+```
+
+### Example
+
+```yaml
+runner:
+  mode: orchestrated
+  orchestrator:
+    type: dagster
+    schedules:
+      - name: stripe_sync
+        config: /app/jobs/stripe.yaml
+        cron: "0 * * * *"
+  
+  secrets:
+    type: azure
+    vault_url: https://dativo-prod.vault.azure.net/
+    prefix: app-
+```
+
+## Migration Guide
+
+### From Filesystem to Environment Variables
+
+If you're currently using filesystem secrets and want to migrate to environment variables:
+
+1. **Export existing secrets to environment variables:**
+
+```bash
+# For each tenant and secret file, create corresponding env vars
+export DATIVO_ACME_STRIPE_API_KEY=$(cat /secrets/acme/stripe.json | jq -r '.api_key')
+export DATIVO_ACME_DATABASE_PASSWORD=$(cat /secrets/acme/postgres.env | grep DB_PASSWORD | cut -d= -f2)
+```
+
+2. **Update your runner.yaml:**
+
+```yaml
+runner:
+  # ... orchestrator config ...
+  secrets:
+    type: env  # Change from filesystem to env
+```
+
+Or simply remove the `secrets` section entirely (env is the default).
+
+### From Filesystem to Cloud Secret Manager
+
+1. **Upload secrets to your cloud provider** (see examples above)
+
+2. **Update your runner.yaml:**
+
+```yaml
+runner:
+  # ... orchestrator config ...
+  secrets:
+    type: aws  # or gcp, azure, vault
+    # ... provider-specific config ...
+```
+
+3. **Configure authentication** (IAM roles, service accounts, etc.)
+
+4. **Test the configuration** before removing filesystem secrets
+
+## Best Practices
+
+1. **Use Environment Variables for Development**
+   - Simple setup
+   - No infrastructure dependencies
+   - Works well with Docker Compose
+
+2. **Use Cloud Secret Managers for Production**
+   - Centralized secret management
+   - Audit logging
+   - Automatic rotation
+   - Fine-grained access control
+
+3. **Never Commit Secrets to Git**
+   - Use `.gitignore` for local secret files
+   - Use environment variables or secret managers
+   - Rotate secrets if accidentally committed
+
+4. **Use Separate Secrets per Tenant**
+   - Better security isolation
+   - Easier access control
+   - Simplified debugging
+
+5. **Implement Secret Rotation**
+   - Regular rotation schedule
+   - Automated rotation where possible
+   - Monitor for expiring secrets
+
+6. **Use Appropriate Permissions**
+   - Principle of least privilege
+   - Read-only access for applications
+   - Separate admin and app credentials
+
+## Troubleshooting
+
+### Secret Not Found
+
+**Environment Variables:**
+```bash
+# Check if variable is set
+echo $DATIVO_ACME_STRIPE_API_KEY
+
+# List all DATIVO variables
+env | grep DATIVO
+```
+
+**Filesystem:**
+```bash
+# Check if file exists
+ls -la /secrets/acme/
+
+# Check file permissions
+ls -l /secrets/acme/stripe.json
+```
+
+**Cloud Providers:**
+- Verify secret exists in the provider's console
+- Check authentication (credentials, IAM roles, service accounts)
+- Verify network connectivity
+- Check application logs for detailed error messages
+
+### Authentication Errors
+
+**HashiCorp Vault:**
+```bash
+# Test vault connection
+vault status -address=https://vault.example.com:8200
+
+# Check token
+vault token lookup
+```
+
+**AWS:**
+```bash
+# Check credentials
+aws sts get-caller-identity
+
+# Test secret access
+aws secretsmanager get-secret-value --secret-id dativo/acme
+```
+
+**GCP:**
+```bash
+# Check credentials
+gcloud auth list
+
+# Test secret access
+gcloud secrets versions access latest --secret=dativo-acme
+```
+
+**Azure:**
+```bash
+# Check credentials
+az account show
+
+# Test secret access
+az keyvault secret show --vault-name my-vault --name dativo-acme-stripe-api-key
+```
+
+## Security Considerations
+
+1. **Encryption in Transit**: All cloud secret managers use TLS/SSL encryption
+2. **Encryption at Rest**: Secrets are encrypted by the provider
+3. **Access Logging**: Enable audit logging for all secret access
+4. **Network Security**: Use private endpoints/VPC when available
+5. **Credential Rotation**: Implement regular rotation policies
+6. **Least Privilege**: Grant only necessary permissions
+7. **Secret Scanning**: Use tools to detect secrets in code
+8. **Environment Separation**: Use different secrets for dev/staging/prod
+
+## Additional Resources
+
+- [HashiCorp Vault Documentation](https://www.vaultproject.io/docs)
+- [AWS Secrets Manager Documentation](https://docs.aws.amazon.com/secretsmanager/)
+- [Google Cloud Secret Manager Documentation](https://cloud.google.com/secret-manager/docs)
+- [Azure Key Vault Documentation](https://docs.microsoft.com/en-us/azure/key-vault/)

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,6 +29,12 @@ pynessie>=0.60.0
 # Storage access
 boto3>=1.28.0
 
+# Secret managers
+hvac>=1.2.0  # HashiCorp Vault
+google-cloud-secret-manager>=2.16.0  # Google Cloud Secret Manager
+azure-keyvault-secrets>=4.7.0  # Azure Key Vault
+azure-identity>=1.13.0  # Azure authentication
+
 # Testing (optional, for development)
 pytest>=7.0.0
 pytest-mock>=3.0.0

--- a/src/dativo_ingest/secrets.py
+++ b/src/dativo_ingest/secrets.py
@@ -1,12 +1,584 @@
-"""Secrets management for loading and validating credentials from filesystem storage."""
+"""Secrets management for loading and validating credentials from multiple secret managers."""
 
 import json
+import logging
 import os
 import re
+from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
+logger = logging.getLogger(__name__)
 
+
+class SecretManager(ABC):
+    """Base class for secret managers."""
+    
+    @abstractmethod
+    def load_secrets(self, tenant_id: str) -> Dict[str, Any]:
+        """Load secrets for a tenant.
+        
+        Args:
+            tenant_id: Tenant identifier
+            
+        Returns:
+            Dictionary of loaded secrets, keyed by secret name
+            
+        Raises:
+            ValueError: If secrets cannot be loaded
+        """
+        pass
+
+
+class EnvironmentSecretManager(SecretManager):
+    """Load secrets from environment variables.
+    
+    This is the default secret manager. It reads secrets from environment variables
+    with the pattern: {TENANT_ID}_{SECRET_NAME} or just {SECRET_NAME}.
+    """
+    
+    def __init__(self, prefix: Optional[str] = None):
+        """Initialize environment secret manager.
+        
+        Args:
+            prefix: Optional prefix for environment variables (e.g., "DATIVO_")
+        """
+        self.prefix = prefix or ""
+    
+    def load_secrets(self, tenant_id: str) -> Dict[str, Any]:
+        """Load secrets from environment variables.
+        
+        Looks for environment variables in the following order:
+        1. {PREFIX}{TENANT_ID}_{SECRET_NAME}
+        2. {PREFIX}{SECRET_NAME}
+        
+        Args:
+            tenant_id: Tenant identifier
+            
+        Returns:
+            Dictionary of loaded secrets
+        """
+        secrets = {}
+        tenant_prefix = f"{self.prefix}{tenant_id.upper()}_"
+        
+        # Scan all environment variables
+        for key, value in os.environ.items():
+            # Check if it matches tenant-specific pattern
+            if key.startswith(tenant_prefix):
+                secret_name = key[len(tenant_prefix):].lower()
+                secrets[secret_name] = value
+            # Check if it matches general pattern with prefix
+            elif self.prefix and key.startswith(self.prefix):
+                secret_name = key[len(self.prefix):].lower()
+                if secret_name not in secrets:  # Don't override tenant-specific
+                    secrets[secret_name] = value
+        
+        logger.info(
+            f"Loaded {len(secrets)} secrets from environment variables for tenant {tenant_id}",
+            extra={"tenant_id": tenant_id, "secret_count": len(secrets)}
+        )
+        
+        return secrets
+
+
+class FilesystemSecretManager(SecretManager):
+    """Load secrets from filesystem storage (original implementation)."""
+    
+    def __init__(self, secrets_dir: Path = Path("/secrets")):
+        """Initialize filesystem secret manager.
+        
+        Args:
+            secrets_dir: Base directory for secrets (default: /secrets)
+        """
+        self.secrets_dir = secrets_dir
+    
+    def load_secrets(self, tenant_id: str) -> Dict[str, Any]:
+        """Load secrets for a tenant from secrets storage.
+        
+        Args:
+            tenant_id: Tenant identifier
+            
+        Returns:
+            Dictionary of loaded secrets, keyed by secret file name (without extension)
+            
+        Raises:
+            ValueError: If secrets directory doesn't exist
+        """
+        tenant_secrets_dir = self.secrets_dir / tenant_id
+        if not tenant_secrets_dir.exists():
+            raise ValueError(f"Secrets directory not found: {tenant_secrets_dir}")
+        
+        secrets = {}
+        
+        # Load all secret files
+        for secret_file in tenant_secrets_dir.iterdir():
+            if secret_file.is_file() and not secret_file.name.startswith("."):
+                secret_name = secret_file.stem  # filename without extension
+                try:
+                    if secret_file.suffix == ".json":
+                        # Load JSON file
+                        with open(secret_file, "r") as f:
+                            content = json.load(f)
+                            # Expand environment variables in JSON values
+                            secrets[secret_name] = _expand_env_vars_in_dict(content)
+                    elif secret_file.suffix == ".env":
+                        # Load .env file (key=value format)
+                        env_vars = {}
+                        with open(secret_file, "r") as f:
+                            for line in f:
+                                line = line.strip()
+                                if line and not line.startswith("#"):
+                                    if "=" in line:
+                                        key, value = line.split("=", 1)
+                                        key = key.strip()
+                                        value = value.strip().strip('"').strip("'")
+                                        # Expand environment variables
+                                        value = os.path.expandvars(value)
+                                        env_vars[key] = value
+                        secrets[secret_name] = env_vars
+                    else:
+                        # Load plain text file
+                        with open(secret_file, "r") as f:
+                            content = f.read().strip()
+                            # Expand environment variables
+                            content = os.path.expandvars(content)
+                            secrets[secret_name] = content
+                except Exception as e:
+                    # Log warning but continue loading other secrets
+                    logger.warning(
+                        f"Failed to load secret file {secret_file}: {e}",
+                        extra={"secret_file": str(secret_file), "error": str(e)},
+                    )
+        
+        return secrets
+
+
+class HashiCorpVaultSecretManager(SecretManager):
+    """Load secrets from HashiCorp Vault."""
+    
+    def __init__(
+        self,
+        url: str,
+        token: Optional[str] = None,
+        mount_point: str = "secret",
+        namespace: Optional[str] = None,
+        verify: bool = True
+    ):
+        """Initialize HashiCorp Vault secret manager.
+        
+        Args:
+            url: Vault server URL (e.g., "https://vault.example.com:8200")
+            token: Vault token (if None, reads from VAULT_TOKEN env var)
+            mount_point: KV secrets engine mount point (default: "secret")
+            namespace: Vault namespace (optional)
+            verify: Whether to verify SSL certificates (default: True)
+        """
+        try:
+            import hvac
+        except ImportError:
+            raise ImportError(
+                "hvac library not installed. Install with: pip install hvac"
+            )
+        
+        self.url = url
+        self.token = token or os.getenv("VAULT_TOKEN")
+        self.mount_point = mount_point
+        self.namespace = namespace
+        self.verify = verify
+        
+        if not self.token:
+            raise ValueError("Vault token not provided. Set VAULT_TOKEN environment variable or pass token parameter.")
+        
+        self.client = hvac.Client(
+            url=self.url,
+            token=self.token,
+            namespace=self.namespace,
+            verify=self.verify
+        )
+        
+        if not self.client.is_authenticated():
+            raise ValueError(f"Failed to authenticate with Vault at {self.url}")
+    
+    def load_secrets(self, tenant_id: str) -> Dict[str, Any]:
+        """Load secrets from Vault KV store.
+        
+        Reads secrets from path: {mount_point}/data/{tenant_id}
+        
+        Args:
+            tenant_id: Tenant identifier
+            
+        Returns:
+            Dictionary of loaded secrets
+            
+        Raises:
+            ValueError: If secrets cannot be loaded
+        """
+        try:
+            # For KV v2, path is: {mount_point}/data/{tenant_id}
+            response = self.client.secrets.kv.v2.read_secret_version(
+                path=tenant_id,
+                mount_point=self.mount_point
+            )
+            
+            secrets = response.get("data", {}).get("data", {})
+            
+            logger.info(
+                f"Loaded {len(secrets)} secrets from Vault for tenant {tenant_id}",
+                extra={"tenant_id": tenant_id, "secret_count": len(secrets)}
+            )
+            
+            return secrets
+        except Exception as e:
+            raise ValueError(f"Failed to load secrets from Vault for tenant {tenant_id}: {e}")
+
+
+class AWSSecretsManagerSecretManager(SecretManager):
+    """Load secrets from AWS Secrets Manager."""
+    
+    def __init__(
+        self,
+        region_name: Optional[str] = None,
+        prefix: Optional[str] = None
+    ):
+        """Initialize AWS Secrets Manager secret manager.
+        
+        Args:
+            region_name: AWS region (if None, uses default from boto3 config)
+            prefix: Optional prefix for secret names (e.g., "dativo/")
+        """
+        try:
+            import boto3
+        except ImportError:
+            raise ImportError(
+                "boto3 library not installed. Install with: pip install boto3"
+            )
+        
+        self.region_name = region_name
+        self.prefix = prefix or ""
+        self.client = boto3.client('secretsmanager', region_name=region_name)
+    
+    def load_secrets(self, tenant_id: str) -> Dict[str, Any]:
+        """Load secrets from AWS Secrets Manager.
+        
+        Looks for secrets with the pattern: {prefix}{tenant_id}/{secret_name}
+        or a single secret named: {prefix}{tenant_id}
+        
+        Args:
+            tenant_id: Tenant identifier
+            
+        Returns:
+            Dictionary of loaded secrets
+            
+        Raises:
+            ValueError: If secrets cannot be loaded
+        """
+        secrets = {}
+        secret_name = f"{self.prefix}{tenant_id}"
+        
+        try:
+            # Try to load a single secret for the tenant
+            response = self.client.get_secret_value(SecretId=secret_name)
+            
+            # Parse the secret value
+            if 'SecretString' in response:
+                secret_value = response['SecretString']
+                try:
+                    # Try to parse as JSON
+                    secrets = json.loads(secret_value)
+                except json.JSONDecodeError:
+                    # If not JSON, store as single value
+                    secrets = {"value": secret_value}
+            else:
+                # Binary secret
+                secrets = {"value": response['SecretBinary']}
+            
+            logger.info(
+                f"Loaded secrets from AWS Secrets Manager for tenant {tenant_id}",
+                extra={"tenant_id": tenant_id, "secret_count": len(secrets)}
+            )
+            
+        except self.client.exceptions.ResourceNotFoundException:
+            # Try to list secrets with tenant prefix
+            try:
+                paginator = self.client.get_paginator('list_secrets')
+                for page in paginator.paginate(
+                    Filters=[
+                        {'Key': 'name', 'Values': [f"{secret_name}/"]}
+                    ]
+                ):
+                    for secret in page['SecretList']:
+                        # Extract secret name after tenant prefix
+                        full_name = secret['Name']
+                        if full_name.startswith(f"{secret_name}/"):
+                            key = full_name[len(f"{secret_name}/"):]
+                            
+                            # Get secret value
+                            response = self.client.get_secret_value(SecretId=full_name)
+                            if 'SecretString' in response:
+                                secrets[key] = response['SecretString']
+                            else:
+                                secrets[key] = response['SecretBinary']
+                
+                if not secrets:
+                    logger.warning(
+                        f"No secrets found in AWS Secrets Manager for tenant {tenant_id}",
+                        extra={"tenant_id": tenant_id}
+                    )
+            except Exception as e:
+                raise ValueError(f"Failed to load secrets from AWS Secrets Manager for tenant {tenant_id}: {e}")
+        except Exception as e:
+            raise ValueError(f"Failed to load secrets from AWS Secrets Manager for tenant {tenant_id}: {e}")
+        
+        return secrets
+
+
+class GCPSecretManagerSecretManager(SecretManager):
+    """Load secrets from Google Cloud Secret Manager."""
+    
+    def __init__(
+        self,
+        project_id: Optional[str] = None,
+        prefix: Optional[str] = None
+    ):
+        """Initialize GCP Secret Manager secret manager.
+        
+        Args:
+            project_id: GCP project ID (if None, uses default from application credentials)
+            prefix: Optional prefix for secret names (e.g., "dativo-")
+        """
+        try:
+            from google.cloud import secretmanager
+        except ImportError:
+            raise ImportError(
+                "google-cloud-secret-manager library not installed. "
+                "Install with: pip install google-cloud-secret-manager"
+            )
+        
+        self.project_id = project_id or os.getenv("GCP_PROJECT_ID")
+        if not self.project_id:
+            raise ValueError(
+                "GCP project ID not provided. Set GCP_PROJECT_ID environment variable or pass project_id parameter."
+            )
+        
+        self.prefix = prefix or ""
+        self.client = secretmanager.SecretManagerServiceClient()
+    
+    def load_secrets(self, tenant_id: str) -> Dict[str, Any]:
+        """Load secrets from GCP Secret Manager.
+        
+        Looks for secrets with the pattern: {prefix}{tenant_id}-{secret_name}
+        or a single secret named: {prefix}{tenant_id}
+        
+        Args:
+            tenant_id: Tenant identifier
+            
+        Returns:
+            Dictionary of loaded secrets
+            
+        Raises:
+            ValueError: If secrets cannot be loaded
+        """
+        secrets = {}
+        secret_base_name = f"{self.prefix}{tenant_id}"
+        
+        try:
+            # List all secrets in the project
+            parent = f"projects/{self.project_id}"
+            
+            for secret in self.client.list_secrets(request={"parent": parent}):
+                secret_name = secret.name.split("/")[-1]
+                
+                # Check if secret belongs to this tenant
+                if secret_name == secret_base_name:
+                    # Single secret for tenant
+                    version_name = f"{secret.name}/versions/latest"
+                    response = self.client.access_secret_version(request={"name": version_name})
+                    payload = response.payload.data.decode("UTF-8")
+                    
+                    try:
+                        # Try to parse as JSON
+                        secrets = json.loads(payload)
+                    except json.JSONDecodeError:
+                        # If not JSON, store as single value
+                        secrets = {"value": payload}
+                    break
+                elif secret_name.startswith(f"{secret_base_name}-"):
+                    # Multiple secrets with tenant prefix
+                    key = secret_name[len(f"{secret_base_name}-"):]
+                    version_name = f"{secret.name}/versions/latest"
+                    response = self.client.access_secret_version(request={"name": version_name})
+                    secrets[key] = response.payload.data.decode("UTF-8")
+            
+            if not secrets:
+                logger.warning(
+                    f"No secrets found in GCP Secret Manager for tenant {tenant_id}",
+                    extra={"tenant_id": tenant_id}
+                )
+            else:
+                logger.info(
+                    f"Loaded {len(secrets)} secrets from GCP Secret Manager for tenant {tenant_id}",
+                    extra={"tenant_id": tenant_id, "secret_count": len(secrets)}
+                )
+            
+        except Exception as e:
+            raise ValueError(f"Failed to load secrets from GCP Secret Manager for tenant {tenant_id}: {e}")
+        
+        return secrets
+
+
+class AzureKeyVaultSecretManager(SecretManager):
+    """Load secrets from Azure Key Vault."""
+    
+    def __init__(
+        self,
+        vault_url: str,
+        credential: Optional[Any] = None,
+        prefix: Optional[str] = None
+    ):
+        """Initialize Azure Key Vault secret manager.
+        
+        Args:
+            vault_url: Azure Key Vault URL (e.g., "https://myvault.vault.azure.net/")
+            credential: Azure credential (if None, uses DefaultAzureCredential)
+            prefix: Optional prefix for secret names (e.g., "dativo-")
+        """
+        try:
+            from azure.keyvault.secrets import SecretClient
+            from azure.identity import DefaultAzureCredential
+        except ImportError:
+            raise ImportError(
+                "azure-keyvault-secrets and azure-identity libraries not installed. "
+                "Install with: pip install azure-keyvault-secrets azure-identity"
+            )
+        
+        self.vault_url = vault_url
+        self.prefix = prefix or ""
+        
+        if credential is None:
+            credential = DefaultAzureCredential()
+        
+        self.client = SecretClient(vault_url=vault_url, credential=credential)
+    
+    def load_secrets(self, tenant_id: str) -> Dict[str, Any]:
+        """Load secrets from Azure Key Vault.
+        
+        Looks for secrets with the pattern: {prefix}{tenant_id}-{secret_name}
+        Note: Azure Key Vault secret names can only contain alphanumeric characters and hyphens.
+        
+        Args:
+            tenant_id: Tenant identifier
+            
+        Returns:
+            Dictionary of loaded secrets
+            
+        Raises:
+            ValueError: If secrets cannot be loaded
+        """
+        secrets = {}
+        secret_prefix = f"{self.prefix}{tenant_id}-"
+        
+        try:
+            # List all secrets in the vault
+            for secret_properties in self.client.list_properties_of_secrets():
+                secret_name = secret_properties.name
+                
+                # Check if secret belongs to this tenant
+                if secret_name.startswith(secret_prefix):
+                    key = secret_name[len(secret_prefix):]
+                    
+                    # Get secret value
+                    secret = self.client.get_secret(secret_name)
+                    secrets[key] = secret.value
+            
+            if not secrets:
+                logger.warning(
+                    f"No secrets found in Azure Key Vault for tenant {tenant_id}",
+                    extra={"tenant_id": tenant_id}
+                )
+            else:
+                logger.info(
+                    f"Loaded {len(secrets)} secrets from Azure Key Vault for tenant {tenant_id}",
+                    extra={"tenant_id": tenant_id, "secret_count": len(secrets)}
+                )
+            
+        except Exception as e:
+            raise ValueError(f"Failed to load secrets from Azure Key Vault for tenant {tenant_id}: {e}")
+        
+        return secrets
+
+
+def create_secret_manager(config: Optional[Dict[str, Any]] = None) -> SecretManager:
+    """Create a secret manager based on configuration.
+    
+    Args:
+        config: Secret manager configuration. If None, uses environment variables (default).
+                Structure:
+                {
+                    "type": "env" | "filesystem" | "vault" | "aws" | "gcp" | "azure",
+                    ... type-specific options ...
+                }
+    
+    Returns:
+        SecretManager instance
+        
+    Raises:
+        ValueError: If configuration is invalid
+    """
+    if config is None:
+        config = {"type": "env"}
+    
+    manager_type = config.get("type", "env").lower()
+    
+    if manager_type == "env" or manager_type == "environment":
+        return EnvironmentSecretManager(
+            prefix=config.get("prefix")
+        )
+    
+    elif manager_type == "filesystem" or manager_type == "file":
+        secrets_dir = config.get("secrets_dir", "/secrets")
+        return FilesystemSecretManager(
+            secrets_dir=Path(secrets_dir)
+        )
+    
+    elif manager_type == "vault" or manager_type == "hashicorp":
+        if "url" not in config:
+            raise ValueError("Vault URL is required for HashiCorp Vault secret manager")
+        return HashiCorpVaultSecretManager(
+            url=config["url"],
+            token=config.get("token"),
+            mount_point=config.get("mount_point", "secret"),
+            namespace=config.get("namespace"),
+            verify=config.get("verify", True)
+        )
+    
+    elif manager_type == "aws" or manager_type == "aws_secrets_manager":
+        return AWSSecretsManagerSecretManager(
+            region_name=config.get("region_name"),
+            prefix=config.get("prefix")
+        )
+    
+    elif manager_type == "gcp" or manager_type == "google":
+        return GCPSecretManagerSecretManager(
+            project_id=config.get("project_id"),
+            prefix=config.get("prefix")
+        )
+    
+    elif manager_type == "azure" or manager_type == "azure_keyvault":
+        if "vault_url" not in config:
+            raise ValueError("Vault URL is required for Azure Key Vault secret manager")
+        return AzureKeyVaultSecretManager(
+            vault_url=config["vault_url"],
+            prefix=config.get("prefix")
+        )
+    
+    else:
+        raise ValueError(
+            f"Unknown secret manager type: {manager_type}. "
+            f"Supported types: env, filesystem, vault, aws, gcp, azure"
+        )
+
+
+# Backward compatibility functions
 def resolve_secret_path(file_template: str, tenant_id: str) -> Path:
     """Resolve secret file path from template.
 
@@ -23,69 +595,35 @@ def resolve_secret_path(file_template: str, tenant_id: str) -> Path:
     return Path(resolved_path)
 
 
-def load_secrets(tenant_id: str, secrets_dir: Path = Path("/secrets")) -> Dict[str, Any]:
-    """Load secrets for a tenant from secrets storage.
+def load_secrets(
+    tenant_id: str,
+    secrets_dir: Path = Path("/secrets"),
+    config: Optional[Dict[str, Any]] = None
+) -> Dict[str, Any]:
+    """Load secrets for a tenant using configured secret manager.
+    
+    This function maintains backward compatibility with the filesystem-based approach
+    while supporting new secret managers through the config parameter.
 
     Args:
         tenant_id: Tenant identifier
-        secrets_dir: Base directory for secrets (default: /secrets)
+        secrets_dir: Base directory for secrets (default: /secrets) - used only for filesystem manager
+        config: Secret manager configuration (if None, uses filesystem for backward compatibility)
 
     Returns:
-        Dictionary of loaded secrets, keyed by secret file name (without extension)
+        Dictionary of loaded secrets, keyed by secret name
 
     Raises:
-        ValueError: If secrets directory doesn't exist
+        ValueError: If secrets cannot be loaded
     """
-    tenant_secrets_dir = secrets_dir / tenant_id
-    if not tenant_secrets_dir.exists():
-        raise ValueError(f"Secrets directory not found: {tenant_secrets_dir}")
-
-    secrets = {}
-
-    # Load all secret files
-    for secret_file in tenant_secrets_dir.iterdir():
-        if secret_file.is_file() and not secret_file.name.startswith("."):
-            secret_name = secret_file.stem  # filename without extension
-            try:
-                if secret_file.suffix == ".json":
-                    # Load JSON file
-                    with open(secret_file, "r") as f:
-                        content = json.load(f)
-                        # Expand environment variables in JSON values
-                        secrets[secret_name] = _expand_env_vars_in_dict(content)
-                elif secret_file.suffix == ".env":
-                    # Load .env file (key=value format)
-                    env_vars = {}
-                    with open(secret_file, "r") as f:
-                        for line in f:
-                            line = line.strip()
-                            if line and not line.startswith("#"):
-                                if "=" in line:
-                                    key, value = line.split("=", 1)
-                                    key = key.strip()
-                                    value = value.strip().strip('"').strip("'")
-                                    # Expand environment variables
-                                    value = os.path.expandvars(value)
-                                    env_vars[key] = value
-                    secrets[secret_name] = env_vars
-                else:
-                    # Load plain text file
-                    with open(secret_file, "r") as f:
-                        content = f.read().strip()
-                        # Expand environment variables
-                        content = os.path.expandvars(content)
-                        secrets[secret_name] = content
-            except Exception as e:
-                # Log warning but continue loading other secrets
-                import logging
-
-                logger = logging.getLogger(__name__)
-                logger.warning(
-                    f"Failed to load secret file {secret_file}: {e}",
-                    extra={"secret_file": str(secret_file), "error": str(e)},
-                )
-
-    return secrets
+    # If config is provided, use the configured secret manager
+    if config is not None:
+        manager = create_secret_manager(config)
+        return manager.load_secrets(tenant_id)
+    
+    # Otherwise, fall back to filesystem manager for backward compatibility
+    manager = FilesystemSecretManager(secrets_dir=secrets_dir)
+    return manager.load_secrets(tenant_id)
 
 
 def _expand_env_vars_in_dict(data: Any) -> Any:
@@ -174,4 +712,3 @@ def validate_secrets_for_connector(secrets: Dict[str, Any], connector_type: str,
         )
 
     return True
-


### PR DESCRIPTION
Add support for multiple secret managers (Env, Filesystem, HashiCorp Vault, AWS, GCP, Azure) to allow users to choose their preferred secure credential storage.

This refactors the secret loading mechanism to be pluggable, making environment variables the new default while ensuring backward compatibility with the existing filesystem-based approach. It provides native integration with major cloud secret services and HashiCorp Vault for improved security and operational flexibility.

---
<a href="https://cursor.com/background-agent?bcId=bc-da3b746a-1076-43e1-b888-be237a4954cd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-da3b746a-1076-43e1-b888-be237a4954cd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

