### PR TITLE
Fix: Increase Airbyte connection check timeout from 30s to 60s

### DIFF
--- a/src/dativo_ingest/connectors/engine_framework.py
+++ b/src/dativo_ingest/connectors/engine_framework.py
@@ -618,7 +618,7 @@ class AirbyteExtractor(BaseEngineExtractor):
                     text=True,
                 )
 
-                stdout, stderr = process.communicate(timeout=30)
+                stdout, stderr = process.communicate(timeout=60)
             finally:
                 # Clean up temp file
                 try:
@@ -712,8 +712,9 @@ class AirbyteExtractor(BaseEngineExtractor):
         except subprocess.TimeoutExpired:
             return {
                 "status": "failed",
-                "message": "Airbyte connection check timeout",
+                "message": "Airbyte connection check timeout after 60 seconds",
                 "error_code": "TIMEOUT_ERROR",
+                "retryable": True,
             }
         except Exception as e:
             return {


### PR DESCRIPTION
## Summary
This PR fixes timeout issues when checking connections for Airbyte connectors (e.g., Stripe).

## Changes
- Increased  timeout from 30 seconds to 60 seconds to match the  method timeout
- Improved error message to include the timeout duration for better debugging
- Marked timeout errors as retryable since they can be transient

## Problem
The 30-second timeout was too short for:
- First-time Docker image pulls
- Container startup time
- Network requests to external APIs (e.g., Stripe)
- Processing time

## Solution
Doubling the timeout to 60 seconds provides sufficient time for connection checks to complete, especially on first run when Docker images need to be pulled.

## Testing
- [ ] Tested with Stripe connector check command
- [ ] Verified timeout error message is clear and informative