### PR TITLE
Runner notification hooks

### DIFF
--- a/configs/runner.yaml
+++ b/configs/runner.yaml
@@ -48,3 +48,11 @@ runner:
           priority: "low"
     
     concurrency_per_tenant: 1         # Serialize per-tenant to protect Nessie commits
+  
+  # Notification hooks (optional) - triggered on job failure only
+  # notifications:
+  #   on_failure:
+  #     command: ["/app/scripts/notify_slack.sh"]
+  #     env:
+  #       SLACK_WEBHOOK_URL: ${SLACK_WEBHOOK_URL}
+  #     timeout_seconds: 15

--- a/docs/NOTIFICATION_HOOKS.md
+++ b/docs/NOTIFICATION_HOOKS.md
@@ -1,0 +1,129 @@
+# Notification Hooks
+
+Notification hooks allow you to execute external scripts when jobs fail. Hooks are configured at the runner level and execute only on hard failures (exit_code = 2).
+
+## Configuration
+
+Hooks are configured in `runner.yaml` under `runner.notifications.on_failure`:
+
+```yaml
+runner:
+  mode: orchestrated
+  orchestrator:
+    type: dagster
+    schedules:
+      - name: my_job
+        config: /app/jobs/my_job.yaml
+        cron: "0 * * * *"
+  
+  notifications:
+    on_failure:
+      command: ["/app/scripts/slack_alert.sh"]
+      timeout_seconds: 15
+      env:
+        SLACK_WEBHOOK_URL: "${SLACK_WEBHOOK_URL}"
+```
+
+## Hook Configuration Fields
+
+- **command**: Command and arguments as an array (required, no shell execution, supports `${VAR}` expansion)
+- **timeout_seconds**: Maximum execution time in seconds (default: 15, max: 60)
+- **env**: Optional environment variables (supports `${VAR}` expansion)
+
+## Environment Variable Expansion
+
+Hooks support environment variable expansion in command arguments and environment variables:
+
+- `${VAR}` - Expands to the value of `VAR`, or empty string if not set
+- `${VAR:-default}` - Expands to `default` if `VAR` is not set
+
+Example:
+```yaml
+command: ["/app/scripts/alert.sh", "--url", "${ALERT_URL:-https://default.example.com}"]
+env:
+  API_KEY: "${ALERT_API_KEY}"
+```
+
+## Hook Payload
+
+Hooks receive job information via a JSON payload file, accessible via the `DATIVO_HOOK_PAYLOAD` environment variable:
+
+```json
+{
+  "tenant_id": "acme",
+  "job_name": "stripe_customers",
+  "config_path": "/app/jobs/acme/stripe_customers.yaml",
+  "exit_code": 2,
+  "failure_reason": "Connection timeout",
+  "summary_path": "/app/state/acme/stripe_customers/runs/run-20240101T120000Z.json"
+}
+```
+
+## Example Hook Script
+
+Here's a simple example hook script that sends a Slack notification:
+
+```bash
+#!/bin/bash
+# /app/scripts/slack_alert.sh
+
+set -e
+
+# Read payload
+PAYLOAD_FILE="${DATIVO_HOOK_PAYLOAD}"
+if [ -z "$PAYLOAD_FILE" ] || [ ! -f "$PAYLOAD_FILE" ]; then
+  echo "ERROR: DATIVO_HOOK_PAYLOAD not set or file not found" >&2
+  exit 1
+fi
+
+# Parse payload
+TENANT_ID=$(jq -r '.tenant_id' "$PAYLOAD_FILE")
+JOB_NAME=$(jq -r '.job_name' "$PAYLOAD_FILE")
+EXIT_CODE=$(jq -r '.exit_code' "$PAYLOAD_FILE")
+FAILURE_REASON=$(jq -r '.failure_reason // "Unknown error"' "$PAYLOAD_FILE")
+
+# Send Slack notification
+curl -X POST "${SLACK_WEBHOOK_URL}" \
+  -H 'Content-Type: application/json' \
+  -d "{
+    \"text\": \"Job Failed: ${JOB_NAME}\",
+    \"blocks\": [
+      {
+        \"type\": \"section\",
+        \"text\": {
+          \"type\": \"mrkdwn\",
+          \"text\": \"*Job Failed*\n*Job:* ${JOB_NAME}\n*Tenant:* ${TENANT_ID}\n*Exit Code:* ${EXIT_CODE}\n*Reason:* ${FAILURE_REASON}\"
+        }
+      }
+    ]
+  }"
+
+exit 0
+```
+
+## Behavior
+
+- **Hooks execute only when exit_code is 2** (hard failure)
+- **Hooks run as external processes** (no shell execution, direct argv array)
+- **Hooks have a timeout** (default: 15 seconds, max: 60 seconds)
+- **Hook failures are logged but never crash the runner** - ingestion results remain accurate even if hooks fail
+- **Secrets are redacted in logs** - command arguments and environment variables with secret patterns (token, key, secret, password) are redacted
+
+## Exit Codes
+
+- `0`: Success - hooks do not execute
+- `1`: Partial success - hooks do not execute
+- `2`: Hard failure - hooks execute automatically
+
+## Security
+
+- Command arguments and environment variables are redacted in logs if they match secret patterns
+- Hooks execute with the same environment as the runner process
+- Hooks should not perform long-running operations (use timeout to prevent this)
+- Hooks must not modify ingestion state or data
+
+## Limitations
+
+- Hooks are runner-level only (not per-job)
+- Summary path may not be available in orchestrated mode (subprocess execution)
+- Hooks execute synchronously after job completion (may add latency)

--- a/docs/RUNNER_AND_ORCHESTRATION.md
+++ b/docs/RUNNER_AND_ORCHESTRATION.md
@@ -403,6 +403,212 @@ Metadata is visible in the Dagster UI for monitoring and debugging.
 
 ---
 
+## Notification Hooks (v1.4.0+)
+
+Notification hooks provide runner-level, failure-only external notifications via simple command hooks.
+
+### Philosophy
+
+Dativo follows a headless, config-only approach for notifications:
+
+- **No embedded services**: Dativo does not implement Slack, Kafka, PagerDuty, etc. internally
+- **User-controlled**: You provide external scripts that integrate with your systems
+- **Failure-only**: Hooks are triggered only when jobs fail (exit code = 2)
+- **Graceful failure**: Hook failures never affect job outcomes
+
+### Configuration
+
+Add a `notifications` block to your `runner.yaml`:
+
+```yaml
+runner:
+  mode: orchestrated
+  orchestrator:
+    type: dagster
+    schedules:
+      - name: stripe_hourly
+        config: /app/jobs/acme/stripe.yaml
+        cron: "0 * * * *"
+  
+  # Notification hooks (optional)
+  notifications:
+    on_failure:
+      command: ["/app/scripts/notify_slack.sh"]
+      env:
+        SLACK_WEBHOOK_URL: ${SLACK_WEBHOOK_URL}
+      timeout_seconds: 15
+```
+
+#### Configuration Fields
+
+| Field | Required | Default | Description |
+|-------|----------|---------|-------------|
+| `notifications` | No | - | Top-level notifications block |
+| `on_failure` | No | - | Hook configuration for job failures |
+| `command` | Yes* | - | Command as argv array (no shell). Required if `on_failure` is present |
+| `env` | No | - | Environment variables with `${VAR}` expansion |
+| `timeout_seconds` | No | 15 | Hook execution timeout (1-60 seconds) |
+
+### Environment Contract
+
+When a hook executes, these environment variables are always injected by the runner:
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `DATIVO_TENANT_ID` | Tenant identifier | `acme` |
+| `DATIVO_JOB_NAME` | Job/schedule name | `stripe_hourly` |
+| `DATIVO_RUN_ID` | Unique run identifier | `2026-01-16T10:03:12Z` |
+| `DATIVO_SUMMARY_PATH` | Absolute path to summary JSON | `/logs/runs/.../summary.json` |
+
+**Environment Precedence** (highest to lowest):
+1. Required `DATIVO_*` variables (always set, override user values)
+2. User-provided `env` (after `${VAR}` expansion)
+3. Existing process environment
+
+### Summary File
+
+For each failed run, a summary JSON file is written:
+
+```json
+{
+  "tenant_id": "acme",
+  "job_name": "stripe_hourly",
+  "run_id": "2026-01-16T10:03:12Z",
+  "status": "failure",
+  "timestamp": "2026-01-16T10:03:12Z",
+  "config_path": "/app/configs/jobs/stripe.yaml",
+  "error": {
+    "message": "Stripe API timeout",
+    "type": "UpstreamError"
+  }
+}
+```
+
+**Rules:**
+- Schema is minimal and stable
+- Never includes secrets
+- Hook scripts may read this file directly
+
+### Example Scripts
+
+Dativo ships example scripts in `examples/scripts/`:
+
+#### Slack Webhook (`notify_slack.sh`)
+
+```yaml
+notifications:
+  on_failure:
+    command: ["/app/scripts/notify_slack.sh"]
+    env:
+      SLACK_WEBHOOK_URL: ${SLACK_WEBHOOK_URL}
+      SLACK_CHANNEL: "#alerts"  # Optional override
+```
+
+#### Generic HTTP Webhook (`notify_webhook.sh`)
+
+```yaml
+notifications:
+  on_failure:
+    command: ["/app/scripts/notify_webhook.sh"]
+    env:
+      WEBHOOK_URL: ${WEBHOOK_URL}
+      WEBHOOK_HEADERS: "Authorization: Bearer ${API_TOKEN}"
+```
+
+### Oneshot Mode
+
+Notification hooks also work in oneshot mode when you provide the runner config:
+
+```bash
+dativo run --config /app/jobs/stripe.yaml --runner-config /app/configs/runner.yaml
+```
+
+### Writing Custom Hook Scripts
+
+Requirements:
+1. **Executable**: Script must be executable (`chmod +x`)
+2. **No shell**: Command is invoked as argv array (no shell interpolation)
+3. **Pure shell + curl**: Avoid external dependencies for portability
+4. **Graceful**: Handle missing summary file gracefully
+5. **Timeout-aware**: Complete within configured timeout
+
+### Explicit Non-Goals
+
+Dativo does **not** ship built-in integrations for:
+- Slack, Teams, Discord
+- Kafka, RabbitMQ
+- PagerDuty, OpsGenie
+- Email, SMS
+
+**If you need Kafka**, write a custom hook script:
+
+```bash
+#!/bin/sh
+# notify_kafka.sh
+cat "$DATIVO_SUMMARY_PATH" | \
+    kafka-console-producer \
+        --broker-list "$KAFKA_BROKERS" \
+        --topic "$KAFKA_TOPIC"
+```
+
+### Failure & Safety Semantics
+
+Hook execution is designed to fail gracefully:
+
+| Condition | Behavior |
+|-----------|----------|
+| Command not found | Log error, continue |
+| Command not executable | Log error, continue |
+| Command times out | Log warning, continue |
+| Command exits non-zero | Log warning, continue |
+
+**Key principle**: The ingestion job failed because ingestion failed — not because notification failed.
+
+### Troubleshooting Notification Hooks
+
+#### Script not found
+
+```
+ERROR: Hook command not found: /app/scripts/notify_slack.sh
+```
+
+- Check that the script exists in your Docker container
+- Verify the path is absolute or relative to working directory
+
+#### Permission denied
+
+```
+ERROR: Hook command not executable: /app/scripts/notify_slack.sh
+```
+
+- Run `chmod +x /app/scripts/notify_slack.sh`
+- Ensure the script has a valid shebang (`#!/bin/sh`)
+
+#### Missing environment variables
+
+```
+ERROR: SLACK_WEBHOOK_URL environment variable is not set
+```
+
+- Add the variable to your `runner.yaml` `env` block
+- Ensure the source environment variable is set
+
+#### Webhook errors
+
+- Check HTTP response codes in logs
+- 401/403: Authentication issues
+- 404: Incorrect URL
+- 5xx: Target service issues
+
+#### Finding summary.json
+
+The summary path is logged when hooks are triggered. Default pattern:
+```
+/logs/runs/{run_id}/summary.json
+```
+
+---
+
 ## Best Practices
 
 ### Retry Configuration
@@ -425,6 +631,15 @@ Metadata is visible in the Dagster UI for monitoring and debugging.
 - Track `records_per_second` for throughput monitoring
 - Alert on high `retry_count` values
 - Use tags for filtering and organization
+
+### Notification Hooks
+
+- Keep hook scripts simple and fast (< 15 seconds)
+- Use pure shell + curl for portability
+- Handle missing summary file gracefully
+- Test hooks independently before deploying
+- Use structured logging in custom scripts
+- Never include secrets in logs or error messages
 
 ---
 

--- a/examples/scripts/README.md
+++ b/examples/scripts/README.md
@@ -1,0 +1,215 @@
+# Dativo Notification Hook Scripts
+
+This directory contains example notification hook scripts for Dativo's runner-level failure notifications.
+
+## Overview
+
+Notification hooks are triggered only on job failure (exit code = 2). They execute external commands provided by the user, following Dativo's philosophy:
+
+- **Headless, config-only**: No built-in integrations, just hooks
+- **No embedded services**: External scripts handle all integrations
+- **User-controlled**: You decide how and where to send notifications
+
+## Available Scripts
+
+### `notify_slack.sh` - Slack Webhook
+
+Sends formatted failure notifications to Slack using incoming webhooks.
+
+**Required Environment Variables:**
+- `SLACK_WEBHOOK_URL`: Slack incoming webhook URL
+
+**Optional Environment Variables:**
+- `SLACK_CHANNEL`: Override target channel
+- `SLACK_USERNAME`: Override bot username (default: "Dativo")
+
+**Example Configuration:**
+
+```yaml
+# runner.yaml
+notifications:
+  on_failure:
+    command: ["/app/scripts/notify_slack.sh"]
+    env:
+      SLACK_WEBHOOK_URL: ${SLACK_WEBHOOK_URL}
+```
+
+### `notify_webhook.sh` - Generic HTTP Webhook
+
+Sends failure notifications to any HTTP endpoint. Useful for custom integrations, monitoring systems, or incident management tools.
+
+**Required Environment Variables:**
+- `WEBHOOK_URL`: HTTP endpoint URL
+
+**Optional Environment Variables:**
+- `WEBHOOK_METHOD`: HTTP method (default: POST)
+- `WEBHOOK_HEADERS`: Additional headers, comma-separated
+- `WEBHOOK_WRAP`: If "true", wrap summary in an envelope
+
+**Example Configuration:**
+
+```yaml
+# runner.yaml
+notifications:
+  on_failure:
+    command: ["/app/scripts/notify_webhook.sh"]
+    env:
+      WEBHOOK_URL: ${WEBHOOK_URL}
+      WEBHOOK_HEADERS: "Authorization: Bearer ${API_TOKEN}"
+```
+
+## Environment Contract
+
+All notification hooks receive these environment variables from the runner:
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `DATIVO_TENANT_ID` | Tenant identifier | `acme` |
+| `DATIVO_JOB_NAME` | Job or schedule name | `stripe_hourly` |
+| `DATIVO_RUN_ID` | Unique run identifier | `2026-01-16T10:03:12Z` |
+| `DATIVO_SUMMARY_PATH` | Absolute path to summary JSON | `/logs/runs/2026-01-16T10-03-12Z/summary.json` |
+
+## Summary File Format
+
+The summary JSON file contains failure details:
+
+```json
+{
+  "tenant_id": "acme",
+  "job_name": "stripe_hourly",
+  "run_id": "2026-01-16T10:03:12Z",
+  "status": "failure",
+  "timestamp": "2026-01-16T10:03:12Z",
+  "config_path": "/app/configs/jobs/stripe.yaml",
+  "error": {
+    "message": "Stripe API timeout",
+    "type": "UpstreamError"
+  }
+}
+```
+
+## Writing Custom Hook Scripts
+
+You can write your own notification hooks for any system. Requirements:
+
+1. **Executable**: Script must be executable (`chmod +x`)
+2. **No shell required**: Scripts are invoked directly via argv (no shell)
+3. **Graceful failure**: Return non-zero on error, but don't crash
+4. **Timeout**: Scripts should complete within the configured timeout (default: 15s)
+
+### Example: PagerDuty Integration
+
+```bash
+#!/bin/sh
+# notify_pagerduty.sh
+curl -X POST \
+  -H "Authorization: Token token=${PAGERDUTY_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d "{
+    \"routing_key\": \"${PAGERDUTY_ROUTING_KEY}\",
+    \"event_action\": \"trigger\",
+    \"dedup_key\": \"${DATIVO_RUN_ID}\",
+    \"payload\": {
+      \"summary\": \"Dativo job failed: ${DATIVO_JOB_NAME}\",
+      \"source\": \"dativo-ingest\",
+      \"severity\": \"error\",
+      \"custom_details\": {
+        \"tenant_id\": \"${DATIVO_TENANT_ID}\",
+        \"run_id\": \"${DATIVO_RUN_ID}\"
+      }
+    }
+  }" \
+  "https://events.pagerduty.com/v2/enqueue"
+```
+
+### Example: Kafka Integration
+
+Dativo does **not** ship built-in Kafka support. If you need Kafka notifications, write a custom hook script:
+
+```bash
+#!/bin/sh
+# notify_kafka.sh
+#
+# Required: kafka-console-producer (or kafkacat/kcat)
+# Environment: KAFKA_BROKERS, KAFKA_TOPIC
+
+if [ -z "$KAFKA_BROKERS" ] || [ -z "$KAFKA_TOPIC" ]; then
+    echo "ERROR: KAFKA_BROKERS and KAFKA_TOPIC required" >&2
+    exit 1
+fi
+
+# Read summary file and publish to Kafka
+if [ -f "$DATIVO_SUMMARY_PATH" ]; then
+    cat "$DATIVO_SUMMARY_PATH" | \
+        kafka-console-producer \
+            --broker-list "$KAFKA_BROKERS" \
+            --topic "$KAFKA_TOPIC"
+else
+    echo "{\"tenant_id\":\"$DATIVO_TENANT_ID\",\"job_name\":\"$DATIVO_JOB_NAME\",\"status\":\"failure\"}" | \
+        kafka-console-producer \
+            --broker-list "$KAFKA_BROKERS" \
+            --topic "$KAFKA_TOPIC"
+fi
+```
+
+**Note**: For Kafka, you'll need to ensure `kafka-console-producer` or `kcat` is available in your Docker image.
+
+## Non-Goals
+
+Dativo explicitly does **not** implement:
+
+- Built-in Slack/Teams/Discord integrations
+- Built-in Kafka/RabbitMQ publishers
+- Built-in PagerDuty/OpsGenie integrations
+- Built-in email notifications
+
+These are all achievable via custom hook scripts, giving you full control over the integration.
+
+## Troubleshooting
+
+### Script not found
+
+```
+ERROR: Hook command not found: /app/scripts/notify_slack.sh
+```
+
+Ensure the script path is correct and the file exists in your Docker container.
+
+### Permission denied
+
+```
+ERROR: Hook command not executable: /app/scripts/notify_slack.sh
+```
+
+Run `chmod +x /app/scripts/notify_slack.sh` to make the script executable.
+
+### Missing environment variables
+
+```
+ERROR: SLACK_WEBHOOK_URL environment variable is not set
+```
+
+Configure the required environment variables in your `runner.yaml`:
+
+```yaml
+notifications:
+  on_failure:
+    env:
+      SLACK_WEBHOOK_URL: ${SLACK_WEBHOOK_URL}  # Reads from process env
+```
+
+### Webhook errors
+
+Check the HTTP response code in the logs. Common issues:
+- **401/403**: Authentication failed - check API tokens
+- **404**: Webhook URL is incorrect
+- **500**: Target service error - check service status
+
+### Finding summary.json
+
+The summary file location is logged when a hook is triggered. Default path pattern:
+```
+/logs/runs/{run_id}/summary.json
+```
+
+You can customize the base directory via the `summary_base_dir` parameter.

--- a/examples/scripts/notify_slack.sh
+++ b/examples/scripts/notify_slack.sh
@@ -1,0 +1,128 @@
+#!/bin/sh
+# Dativo Notification Hook: Slack Webhook
+#
+# This script sends job failure notifications to Slack via incoming webhook.
+# It uses the Slack Block Kit format for a rich, formatted message.
+#
+# Required Environment Variables (injected by runner):
+#   DATIVO_TENANT_ID    - Tenant identifier
+#   DATIVO_JOB_NAME     - Job/schedule name
+#   DATIVO_RUN_ID       - Unique run identifier
+#   DATIVO_SUMMARY_PATH - Path to failure summary JSON file
+#
+# User-Provided Environment Variables (via runner.yaml):
+#   SLACK_WEBHOOK_URL   - Slack incoming webhook URL (required)
+#   SLACK_CHANNEL       - Override channel (optional)
+#   SLACK_USERNAME      - Override bot username (optional, default: "Dativo")
+#
+# Usage in runner.yaml:
+#   notifications:
+#     on_failure:
+#       command: ["/app/scripts/notify_slack.sh"]
+#       env:
+#         SLACK_WEBHOOK_URL: ${SLACK_WEBHOOK_URL}
+#
+# Exit Codes:
+#   0 - Success
+#   1 - Missing required environment variables
+#   2 - curl command failed
+#
+
+set -e
+
+# Validate required environment variables
+if [ -z "$SLACK_WEBHOOK_URL" ]; then
+    echo "ERROR: SLACK_WEBHOOK_URL environment variable is not set" >&2
+    exit 1
+fi
+
+if [ -z "$DATIVO_TENANT_ID" ] || [ -z "$DATIVO_JOB_NAME" ] || [ -z "$DATIVO_RUN_ID" ]; then
+    echo "ERROR: Required DATIVO_* environment variables are not set" >&2
+    exit 1
+fi
+
+# Set defaults
+SLACK_USERNAME="${SLACK_USERNAME:-Dativo}"
+
+# Extract error message from summary file if available
+ERROR_MESSAGE="Job execution failed"
+if [ -n "$DATIVO_SUMMARY_PATH" ] && [ -f "$DATIVO_SUMMARY_PATH" ]; then
+    # Try to extract error message using grep/sed (pure shell, no jq dependency)
+    ERROR_MESSAGE=$(grep -o '"message"[[:space:]]*:[[:space:]]*"[^"]*"' "$DATIVO_SUMMARY_PATH" | head -1 | sed 's/.*"message"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/' || echo "Job execution failed")
+    
+    # Escape special characters for JSON
+    ERROR_MESSAGE=$(echo "$ERROR_MESSAGE" | sed 's/\\/\\\\/g' | sed 's/"/\\"/g' | sed 's/\n/\\n/g')
+fi
+
+# Build Slack Block Kit payload
+# Using heredoc for multiline JSON
+PAYLOAD=$(cat <<EOF
+{
+    "username": "${SLACK_USERNAME}",
+    "icon_emoji": ":warning:",
+    "blocks": [
+        {
+            "type": "header",
+            "text": {
+                "type": "plain_text",
+                "text": ":x: Dativo Job Failed",
+                "emoji": true
+            }
+        },
+        {
+            "type": "section",
+            "fields": [
+                {
+                    "type": "mrkdwn",
+                    "text": "*Tenant:*\n${DATIVO_TENANT_ID}"
+                },
+                {
+                    "type": "mrkdwn",
+                    "text": "*Job:*\n${DATIVO_JOB_NAME}"
+                },
+                {
+                    "type": "mrkdwn",
+                    "text": "*Run ID:*\n\`${DATIVO_RUN_ID}\`"
+                }
+            ]
+        },
+        {
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": "*Error:*\n\`\`\`${ERROR_MESSAGE}\`\`\`"
+            }
+        },
+        {
+            "type": "context",
+            "elements": [
+                {
+                    "type": "mrkdwn",
+                    "text": "Summary: \`${DATIVO_SUMMARY_PATH:-N/A}\`"
+                }
+            ]
+        }
+    ]
+}
+EOF
+)
+
+# Add optional channel override
+if [ -n "$SLACK_CHANNEL" ]; then
+    PAYLOAD=$(echo "$PAYLOAD" | sed "s/\"username\"/\"channel\": \"${SLACK_CHANNEL}\", \"username\"/")
+fi
+
+# Send to Slack
+HTTP_RESPONSE=$(curl -s -o /dev/null -w "%{http_code}" \
+    -X POST \
+    -H "Content-Type: application/json" \
+    -d "$PAYLOAD" \
+    "$SLACK_WEBHOOK_URL")
+
+if [ "$HTTP_RESPONSE" -ge 200 ] && [ "$HTTP_RESPONSE" -lt 300 ]; then
+    echo "Slack notification sent successfully (HTTP $HTTP_RESPONSE)"
+    exit 0
+else
+    echo "ERROR: Slack notification failed (HTTP $HTTP_RESPONSE)" >&2
+    exit 2
+fi

--- a/examples/scripts/notify_webhook.sh
+++ b/examples/scripts/notify_webhook.sh
@@ -86,32 +86,40 @@ EOF
 )
 fi
 
-# Build curl command
-CURL_CMD="curl -s -o /dev/null -w \"%{http_code}\" -X $WEBHOOK_METHOD"
-CURL_CMD="$CURL_CMD -H \"Content-Type: application/json\""
-
-# Add custom headers if provided
-if [ -n "$WEBHOOK_HEADERS" ]; then
-    # Parse comma-separated headers
-    echo "$WEBHOOK_HEADERS" | tr ',' '\n' | while read -r header; do
-        header=$(echo "$header" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
-        if [ -n "$header" ]; then
-            CURL_CMD="$CURL_CMD -H \"$header\""
-        fi
-    done
-fi
-
 # Execute request
 # Note: Using a temp file to avoid issues with special characters in payload
 TEMP_PAYLOAD=$(mktemp)
 echo "$PAYLOAD" > "$TEMP_PAYLOAD"
 
-HTTP_RESPONSE=$(curl -s -o /dev/null -w "%{http_code}" \
-    -X "$WEBHOOK_METHOD" \
-    -H "Content-Type: application/json" \
-    ${WEBHOOK_HEADERS:+-H "$WEBHOOK_HEADERS"} \
-    -d @"$TEMP_PAYLOAD" \
-    "$WEBHOOK_URL")
+# Build and execute curl command with properly parsed headers
+if [ -n "$WEBHOOK_HEADERS" ]; then
+    # Parse comma-separated headers and build curl command
+    # Save original IFS and set to comma for splitting
+    OLD_IFS="$IFS"
+    IFS=','
+    # Start building curl command arguments
+    set -- curl -s -o /dev/null -w "%{http_code}" -X "$WEBHOOK_METHOD" -H "Content-Type: application/json"
+    # Add each header as a separate -H argument
+    for header in $WEBHOOK_HEADERS; do
+        # Trim whitespace from header
+        header=$(echo "$header" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+        if [ -n "$header" ]; then
+            set -- "$@" -H "$header"
+        fi
+    done
+    # Restore IFS
+    IFS="$OLD_IFS"
+    # Add payload and URL, then execute
+    set -- "$@" -d @"$TEMP_PAYLOAD" "$WEBHOOK_URL"
+    HTTP_RESPONSE=$("$@")
+else
+    # No custom headers - simple curl command
+    HTTP_RESPONSE=$(curl -s -o /dev/null -w "%{http_code}" \
+        -X "$WEBHOOK_METHOD" \
+        -H "Content-Type: application/json" \
+        -d @"$TEMP_PAYLOAD" \
+        "$WEBHOOK_URL")
+fi
 
 # Cleanup
 rm -f "$TEMP_PAYLOAD"

--- a/examples/scripts/notify_webhook.sh
+++ b/examples/scripts/notify_webhook.sh
@@ -1,0 +1,125 @@
+#!/bin/sh
+# Dativo Notification Hook: Generic HTTP Webhook
+#
+# This script sends job failure notifications to any HTTP endpoint.
+# It POSTs the failure summary JSON (or wraps it in a minimal envelope).
+#
+# Required Environment Variables (injected by runner):
+#   DATIVO_TENANT_ID    - Tenant identifier
+#   DATIVO_JOB_NAME     - Job/schedule name
+#   DATIVO_RUN_ID       - Unique run identifier
+#   DATIVO_SUMMARY_PATH - Path to failure summary JSON file
+#
+# User-Provided Environment Variables (via runner.yaml):
+#   WEBHOOK_URL         - HTTP endpoint URL (required)
+#   WEBHOOK_METHOD      - HTTP method (optional, default: POST)
+#   WEBHOOK_HEADERS     - Additional headers, comma-separated (optional)
+#                         Example: "Authorization: Bearer token,X-Custom: value"
+#   WEBHOOK_WRAP        - If "true", wrap summary in envelope (optional)
+#
+# Usage in runner.yaml:
+#   notifications:
+#     on_failure:
+#       command: ["/app/scripts/notify_webhook.sh"]
+#       env:
+#         WEBHOOK_URL: ${WEBHOOK_URL}
+#         WEBHOOK_HEADERS: "Authorization: Bearer ${API_TOKEN}"
+#
+# Exit Codes:
+#   0 - Success (2xx response)
+#   1 - Missing required environment variables
+#   2 - curl command failed or non-2xx response
+#
+
+set -e
+
+# Validate required environment variables
+if [ -z "$WEBHOOK_URL" ]; then
+    echo "ERROR: WEBHOOK_URL environment variable is not set" >&2
+    exit 1
+fi
+
+if [ -z "$DATIVO_TENANT_ID" ] || [ -z "$DATIVO_JOB_NAME" ] || [ -z "$DATIVO_RUN_ID" ]; then
+    echo "ERROR: Required DATIVO_* environment variables are not set" >&2
+    exit 1
+fi
+
+# Set defaults
+WEBHOOK_METHOD="${WEBHOOK_METHOD:-POST}"
+
+# Build payload
+if [ -n "$DATIVO_SUMMARY_PATH" ] && [ -f "$DATIVO_SUMMARY_PATH" ]; then
+    if [ "$WEBHOOK_WRAP" = "true" ]; then
+        # Wrap summary in envelope
+        SUMMARY_CONTENT=$(cat "$DATIVO_SUMMARY_PATH")
+        PAYLOAD=$(cat <<EOF
+{
+    "event_type": "dativo.job.failure",
+    "timestamp": "$(date -u +"%Y-%m-%dT%H:%M:%SZ")",
+    "tenant_id": "${DATIVO_TENANT_ID}",
+    "job_name": "${DATIVO_JOB_NAME}",
+    "run_id": "${DATIVO_RUN_ID}",
+    "summary": ${SUMMARY_CONTENT}
+}
+EOF
+)
+    else
+        # Send raw summary JSON
+        PAYLOAD=$(cat "$DATIVO_SUMMARY_PATH")
+    fi
+else
+    # Summary file not available - create minimal payload
+    PAYLOAD=$(cat <<EOF
+{
+    "event_type": "dativo.job.failure",
+    "timestamp": "$(date -u +"%Y-%m-%dT%H:%M:%SZ")",
+    "tenant_id": "${DATIVO_TENANT_ID}",
+    "job_name": "${DATIVO_JOB_NAME}",
+    "run_id": "${DATIVO_RUN_ID}",
+    "status": "failure",
+    "error": {
+        "message": "Summary file not available",
+        "type": "UnknownError"
+    }
+}
+EOF
+)
+fi
+
+# Build curl command
+CURL_CMD="curl -s -o /dev/null -w \"%{http_code}\" -X $WEBHOOK_METHOD"
+CURL_CMD="$CURL_CMD -H \"Content-Type: application/json\""
+
+# Add custom headers if provided
+if [ -n "$WEBHOOK_HEADERS" ]; then
+    # Parse comma-separated headers
+    echo "$WEBHOOK_HEADERS" | tr ',' '\n' | while read -r header; do
+        header=$(echo "$header" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+        if [ -n "$header" ]; then
+            CURL_CMD="$CURL_CMD -H \"$header\""
+        fi
+    done
+fi
+
+# Execute request
+# Note: Using a temp file to avoid issues with special characters in payload
+TEMP_PAYLOAD=$(mktemp)
+echo "$PAYLOAD" > "$TEMP_PAYLOAD"
+
+HTTP_RESPONSE=$(curl -s -o /dev/null -w "%{http_code}" \
+    -X "$WEBHOOK_METHOD" \
+    -H "Content-Type: application/json" \
+    ${WEBHOOK_HEADERS:+-H "$WEBHOOK_HEADERS"} \
+    -d @"$TEMP_PAYLOAD" \
+    "$WEBHOOK_URL")
+
+# Cleanup
+rm -f "$TEMP_PAYLOAD"
+
+if [ "$HTTP_RESPONSE" -ge 200 ] && [ "$HTTP_RESPONSE" -lt 300 ]; then
+    echo "Webhook notification sent successfully (HTTP $HTTP_RESPONSE)"
+    exit 0
+else
+    echo "ERROR: Webhook notification failed (HTTP $HTTP_RESPONSE)" >&2
+    exit 2
+fi

--- a/src/dativo_ingest/cli.py
+++ b/src/dativo_ingest/cli.py
@@ -21,11 +21,12 @@ from .cli_connectors import (
     connectors_sync_command,
 )
 from .cli_validate import validate_asset_command, validate_config_command
-from .config import JobConfig, RunnerConfig, SourceConfig
+from .config import JobConfig, NotificationsConfig, RunnerConfig, SourceConfig
 from .job_executor import JobExecutor
 from .logging import get_logger, setup_logging
 from .metrics_config import resolve_metrics_config
 from .metrics_otel import configure_otel_metrics
+from .notification_hooks import execute_failure_notification
 from .secrets import load_secret_manager_config, load_secrets_and_set_env
 from .startup import startup_sequence
 from .validator import ConnectorValidator
@@ -88,6 +89,25 @@ def run_command(args: argparse.Namespace) -> int:
         print(f"ERROR: {exc}", file=sys.stderr)
         return 2
 
+    # Load notifications config from runner config if provided
+    notifications_config = None
+    runner_config_path = getattr(args, "runner_config", None)
+    if runner_config_path:
+        try:
+            runner_config = RunnerConfig.from_yaml(runner_config_path)
+            notifications_config = runner_config.notifications
+        except SystemExit:
+            # RunnerConfig.from_yaml already prints error to stderr
+            print(
+                "WARNING: Failed to load runner config, notifications disabled",
+                file=sys.stderr,
+            )
+        except Exception as e:
+            print(
+                f"WARNING: Failed to load runner config: {e}, notifications disabled",
+                file=sys.stderr,
+            )
+
     # Check if running from directory or single file
     if args.job_dir:
         # Run startup sequence and execute all jobs
@@ -144,7 +164,12 @@ def run_command(args: argparse.Namespace) -> int:
         results = []
         for job_config in jobs:
             result = _execute_single_job(
-                job_config, args.mode, dry_run=dry_run, dry_run_config=dry_run_config
+                job_config,
+                args.mode,
+                dry_run=dry_run,
+                dry_run_config=dry_run_config,
+                notifications_config=notifications_config,
+                config_path=str(args.job_dir),
             )
             results.append(result)
 
@@ -226,7 +251,12 @@ def run_command(args: argparse.Namespace) -> int:
                 )
 
         return _execute_single_job(
-            job_config, args.mode, dry_run=dry_run, dry_run_config=dry_run_config
+            job_config,
+            args.mode,
+            dry_run=dry_run,
+            dry_run_config=dry_run_config,
+            notifications_config=notifications_config,
+            config_path=args.config,
         )
 
 
@@ -235,6 +265,8 @@ def _execute_single_job(
     mode: str,
     dry_run: bool = False,
     dry_run_config: "DryRunConfig" = None,
+    notifications_config: NotificationsConfig = None,
+    config_path: str = None,
 ) -> int:
     """Execute a single job configuration.
 
@@ -243,14 +275,44 @@ def _execute_single_job(
         mode: Execution mode
         dry_run: If True, perform discovery and sample extraction without writing
         dry_run_config: Optional dry-run configuration with sample size and timeout
+        notifications_config: Optional notifications config for failure hooks
+        config_path: Path to the job config file (for error reporting)
 
     Returns:
         Exit code (0=success, 1=partial, 2=failure)
     """
+    from datetime import datetime, timezone
+
     executor = JobExecutor(
         job_config, mode=mode, dry_run=dry_run, dry_run_config=dry_run_config
     )
-    return executor.execute()
+    exit_code = executor.execute()
+
+    # Trigger failure notification hook if configured (only for exit_code = 2)
+    if exit_code == 2 and notifications_config and not dry_run:
+        run_id = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+        # Get error message from run summary if available
+        error_message = "Job execution failed"
+        error_type = "JobExecutionError"
+        if executor.run_summary and executor.run_summary.ingestion.error:
+            error_info = executor.run_summary.ingestion.error
+            if error_info.error_message:
+                error_message = error_info.error_message
+            if error_info.error_type:
+                error_type = error_info.error_type
+
+        execute_failure_notification(
+            config=notifications_config,
+            tenant_id=job_config.tenant_id,
+            job_name=job_config.asset or "unknown",
+            run_id=run_id,
+            config_path=config_path or "unknown",
+            error_message=error_message,
+            error_type=error_type,
+        )
+
+    return exit_code
 
 
 def check_command(args: argparse.Namespace) -> int:
@@ -679,6 +741,11 @@ Examples:
         action="store_true",
         help="Output results in JSON format (for dry-run mode).",
     )
+    run_parser.add_argument(
+        "--runner-config",
+        help="Path to runner configuration YAML file. If provided, notification hooks "
+        "will be loaded from this config and executed on job failure.",
+    )
 
     # Ingest command (primary, recommended)
     ingest_parser = subparsers.add_parser(
@@ -757,6 +824,11 @@ Examples:
         "--json",
         action="store_true",
         help="Output results in JSON format (for dry-run mode).",
+    )
+    ingest_parser.add_argument(
+        "--runner-config",
+        help="Path to runner configuration YAML file. If provided, notification hooks "
+        "will be loaded from this config and executed on job failure.",
     )
 
     # Start command

--- a/src/dativo_ingest/cli.py
+++ b/src/dativo_ingest/cli.py
@@ -290,26 +290,42 @@ def _execute_single_job(
 
     # Trigger failure notification hook if configured (only for exit_code = 2)
     if exit_code == 2 and notifications_config and not dry_run:
-        run_id = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
-
         # Get error message from run summary if available
-        error_message = "Job execution failed"
-        error_type = "JobExecutionError"
+        failure_reason = "Job execution failed"
         if executor.run_summary and executor.run_summary.ingestion.error:
             error_info = executor.run_summary.ingestion.error
             if error_info.error_message:
-                error_message = error_info.error_message
-            if error_info.error_type:
-                error_type = error_info.error_type
+                failure_reason = error_info.error_message
+
+        # Get summary path if available
+        summary_path = None
+        if executor.run_summary:
+            # Try to determine summary path from state directory
+            state_dir = os.getenv("STATE_DIR", ".local/state")
+            if not os.path.isabs(state_dir):
+                state_dir = os.path.abspath(state_dir)
+            job_name = job_config.asset or "unknown-job"
+            tenant_safe = job_config.tenant_id.replace("/", "_")
+            job_safe = job_name.replace("/", "_")
+            run_timestamp = executor.run_summary.run.id
+            summary_file = (
+                Path(state_dir)
+                / tenant_safe
+                / job_safe
+                / "runs"
+                / f"run-{run_timestamp}.json"
+            )
+            if summary_file.exists():
+                summary_path = str(summary_file.absolute())
 
         execute_failure_notification(
             config=notifications_config,
             tenant_id=job_config.tenant_id,
             job_name=job_config.asset or "unknown",
-            run_id=run_id,
             config_path=config_path or "unknown",
-            error_message=error_message,
-            error_type=error_type,
+            exit_code=exit_code,
+            failure_reason=failure_reason,
+            summary_path=summary_path,
         )
 
     return exit_code

--- a/src/dativo_ingest/config.py
+++ b/src/dativo_ingest/config.py
@@ -1163,6 +1163,51 @@ class OrchestratorConfig(BaseModel):
     concurrency_per_tenant: int = Field(default=1, ge=1)
 
 
+class OnFailureHookConfig(BaseModel):
+    """Configuration for on_failure notification hook.
+
+    This defines an external command to execute when a job fails.
+    The command receives environment variables with job context.
+    """
+
+    command: List[str] = Field(
+        ...,
+        min_length=1,
+        description="Command to execute as argv array (no shell). "
+        "Example: ['/app/scripts/notify_slack.sh']",
+    )
+    env: Optional[Dict[str, str]] = Field(
+        default=None,
+        description="Environment variables to pass to the hook. "
+        "Supports ${VAR} expansion from process environment. "
+        "Example: {'SLACK_WEBHOOK_URL': '${SLACK_WEBHOOK_URL}'}",
+    )
+    timeout_seconds: int = Field(
+        default=15,
+        ge=1,
+        le=60,
+        description="Timeout for hook execution in seconds (default: 15, max: 60)",
+    )
+
+
+class NotificationsConfig(BaseModel):
+    """Notification hooks configuration for runner-level notifications.
+
+    Notifications are triggered only on job failure (exit_code = 2).
+    They execute external commands provided by the user.
+
+    Dativo does NOT implement internal Slack, Kafka, PagerDuty, etc. integrations.
+    Instead, it provides a hook mechanism for users to integrate with any system
+    via custom scripts.
+    """
+
+    on_failure: Optional[OnFailureHookConfig] = Field(
+        default=None,
+        description="Hook configuration for job failure notifications. "
+        "Triggered when a job exits with code 2 (failure).",
+    )
+
+
 class RunnerConfig(BaseModel):
     """Runner configuration model."""
 
@@ -1170,6 +1215,11 @@ class RunnerConfig(BaseModel):
     orchestrator: OrchestratorConfig
     metrics: Optional[MetricsConfig] = Field(
         default=None, description="Global metrics configuration for orchestrated mode"
+    )
+    notifications: Optional[NotificationsConfig] = Field(
+        default=None,
+        description="Notification hooks configuration. "
+        "Hooks are triggered on job failure to notify external systems.",
     )
 
     @classmethod
@@ -1209,6 +1259,12 @@ class RunnerConfig(BaseModel):
         if data is None:
             print(f"ERROR: Runner config file is empty: {path}", file=sys.stderr)
             sys.exit(2)
+
+        # Support both formats:
+        # 1. Direct format: { mode: ..., orchestrator: ... }
+        # 2. Wrapped format: { runner: { mode: ..., orchestrator: ... } }
+        if "runner" in data and isinstance(data["runner"], dict):
+            data = data["runner"]
 
         try:
             return cls(**data)

--- a/src/dativo_ingest/notification_hooks.py
+++ b/src/dativo_ingest/notification_hooks.py
@@ -173,7 +173,10 @@ def _create_hook_payload(
         "exit_code": exit_code,
         "failure_reason": failure_reason,
     }
-    if summary_path:
+    # Only add summary_path if it's a non-empty string
+    # This handles the case where summary_path might be Path("") which is truthy
+    # but should not be used as a valid path
+    if summary_path and isinstance(summary_path, str) and summary_path.strip():
         payload["summary_path"] = summary_path
 
     # Create temporary file that will be cleaned up after hook execution
@@ -248,6 +251,29 @@ def _execute_hook(
     expanded_user_env = expand_hook_env(user_env)
     env.update(expanded_user_env)
     env["DATIVO_HOOK_PAYLOAD"] = str(payload_path.absolute())
+
+    # Extract summary_path from payload and set DATIVO_SUMMARY_PATH
+    # Only set if summary_path exists and is a non-empty string
+    # This handles the case where summary_path might be Path("") which is truthy
+    # but should not be used as a valid path
+    try:
+        with open(payload_path, "r") as f:
+            payload_data = json.load(f)
+        summary_path_value = payload_data.get("summary_path")
+        # Only set if summary_path is a non-empty string
+        # Check explicitly for string type and non-empty to avoid Path("") issues
+        if (
+            summary_path_value
+            and isinstance(summary_path_value, str)
+            and summary_path_value.strip()
+        ):
+            env["DATIVO_SUMMARY_PATH"] = summary_path_value
+    except Exception as e:
+        # If we can't read the payload, log but don't fail
+        logger.warning(
+            f"Failed to read payload for DATIVO_SUMMARY_PATH: {e}",
+            extra={"event_type": "notification_hook_payload_read_warning"},
+        )
 
     # Log execution start (with redacted command and env)
     redacted_command = _redact_command_args(expanded_command)

--- a/src/dativo_ingest/notification_hooks.py
+++ b/src/dativo_ingest/notification_hooks.py
@@ -1,25 +1,18 @@
 """Notification hooks for runner-level failure notifications.
 
-This module implements the notification hook system that executes external
-commands when jobs fail. It follows Dativo's philosophy:
-- Headless, config-only
-- No embedded services
-- No opinionated integrations in core logic
-
-Hooks are triggered only on job failure (exit_code = 2).
+Hooks execute external scripts when jobs fail (exit_code = 2).
+Minimal, safe implementation that never compromises ingestion correctness.
 """
 
 import json
 import os
 import re
 import subprocess
-import time
-from datetime import datetime, timezone
+import tempfile
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
 from .logging import get_logger
-
 
 # Patterns for redacting sensitive values in logs
 SECRET_PATTERNS = [
@@ -63,6 +56,8 @@ def _redact_env_for_logging(env: Dict[str, str]) -> Dict[str, str]:
 def _expand_env_variable(value: str) -> str:
     """Expand ${VAR} style environment variable references.
 
+    Supports ${VAR} and ${VAR:-default} syntax.
+
     Args:
         value: String potentially containing ${VAR} references
 
@@ -72,10 +67,25 @@ def _expand_env_variable(value: str) -> str:
     pattern = re.compile(r"\$\{([^}]+)\}")
 
     def replace(match: re.Match) -> str:
-        var_name = match.group(1)
-        return os.environ.get(var_name, "")
+        var_spec = match.group(1)
+        if ":-" in var_spec:
+            var_name, default = var_spec.split(":-", 1)
+            return os.environ.get(var_name, default)
+        return os.environ.get(var_spec, "")
 
     return pattern.sub(replace, value)
+
+
+def _expand_command_args(args: List[str]) -> List[str]:
+    """Expand ${VAR} references in command arguments.
+
+    Args:
+        args: Command arguments with potential ${VAR} references
+
+    Returns:
+        List with all ${VAR} references expanded
+    """
+    return [_expand_env_variable(arg) for arg in args]
 
 
 def expand_hook_env(
@@ -101,418 +111,298 @@ def expand_hook_env(
     return expanded
 
 
-class FailureSummary:
-    """Generates failure summary JSON for notification hooks.
+def _redact_command_args(args: List[str]) -> List[str]:
+    """Redact sensitive values in command arguments for logging.
 
-    The summary file contains minimal, stable information about the failed run.
-    It never includes secrets and follows a stable schema contract.
+    Args:
+        args: Command arguments
+
+    Returns:
+        List with sensitive values redacted
     """
+    redacted = []
+    for arg in args:
+        # Check if arg contains secret patterns (e.g., --token=secret)
+        should_redact = False
+        for pattern in SECRET_PATTERNS:
+            if pattern.search(arg):
+                should_redact = True
+                break
 
-    def __init__(
-        self,
-        tenant_id: str,
-        job_name: str,
-        run_id: str,
-        config_path: str,
-        error_message: str,
-        error_type: str = "UnknownError",
-        timestamp: Optional[datetime] = None,
-    ):
-        """Initialize failure summary.
+        if should_redact:
+            # Redact value after = or : separator
+            if "=" in arg:
+                key, _ = arg.split("=", 1)
+                redacted.append(f"{key}=[REDACTED]")
+            elif ":" in arg and not arg.startswith("http"):
+                key, _ = arg.split(":", 1)
+                redacted.append(f"{key}:[REDACTED]")
+            else:
+                redacted.append("[REDACTED]")
+        else:
+            redacted.append(arg)
 
-        Args:
-            tenant_id: Tenant identifier
-            job_name: Job/schedule name
-            run_id: Unique run identifier (timestamp-based)
-            config_path: Path to job configuration file
-            error_message: Human-readable error message
-            error_type: Error type classification
-            timestamp: Failure timestamp (defaults to now)
-        """
-        self.tenant_id = tenant_id
-        self.job_name = job_name
-        self.run_id = run_id
-        self.config_path = config_path
-        self.error_message = error_message
-        self.error_type = error_type
-        self.timestamp = timestamp or datetime.now(timezone.utc)
-
-    def to_dict(self) -> Dict[str, Any]:
-        """Convert to dictionary representation.
-
-        Returns:
-            Dict with summary fields
-        """
-        return {
-            "tenant_id": self.tenant_id,
-            "job_name": self.job_name,
-            "run_id": self.run_id,
-            "status": "failure",
-            "timestamp": self.timestamp.isoformat(),
-            "config_path": self.config_path,
-            "error": {
-                "message": self.error_message,
-                "type": self.error_type,
-            },
-        }
-
-    def to_json(self, indent: int = 2) -> str:
-        """Convert to JSON string.
-
-        Args:
-            indent: JSON indentation level
-
-        Returns:
-            JSON string representation
-        """
-        return json.dumps(self.to_dict(), indent=indent)
-
-    def write_to_file(self, base_dir: str = "/logs/runs") -> Path:
-        """Write summary to a deterministic file path.
-
-        Creates directory structure if needed:
-        {base_dir}/{run_id}/summary.json
-
-        Args:
-            base_dir: Base directory for run logs
-
-        Returns:
-            Path to written summary file
-        """
-        # Use run_id for directory name (sanitize for filesystem)
-        run_dir_name = self.run_id.replace(":", "-").replace("/", "-")
-        summary_dir = Path(base_dir) / run_dir_name
-        summary_dir.mkdir(parents=True, exist_ok=True)
-
-        summary_path = summary_dir / "summary.json"
-        with open(summary_path, "w") as f:
-            f.write(self.to_json())
-
-        return summary_path
+    return redacted
 
 
-class NotificationHookExecutor:
-    """Executes notification hooks for job failures.
+def _create_hook_payload(
+    tenant_id: str,
+    job_name: str,
+    config_path: str,
+    exit_code: int,
+    failure_reason: str,
+    summary_path: Optional[str] = None,
+) -> Path:
+    """Create JSON payload file for hook execution.
 
-    This class handles:
-    - Command execution (argv-based, no shell)
-    - Environment variable injection
-    - Timeout handling
-    - Graceful failure (never crashes the runner)
-    - Secret redaction in logs
+    Args:
+        tenant_id: Tenant identifier
+        job_name: Job name
+        config_path: Path to job configuration
+        exit_code: Job exit code (should be 2 for failures)
+        failure_reason: Human-readable failure reason
+        summary_path: Optional path to run summary file
+
+    Returns:
+        Path to temporary payload file
     """
+    payload = {
+        "tenant_id": tenant_id,
+        "job_name": job_name,
+        "config_path": config_path,
+        "exit_code": exit_code,
+        "failure_reason": failure_reason,
+    }
+    if summary_path:
+        payload["summary_path"] = summary_path
 
-    # Required DATIVO_* environment variables injected by runner
-    REQUIRED_ENV_VARS = [
-        "DATIVO_TENANT_ID",
-        "DATIVO_JOB_NAME",
-        "DATIVO_RUN_ID",
-        "DATIVO_SUMMARY_PATH",
-    ]
+    # Create temporary file that will be cleaned up after hook execution
+    fd, payload_path = tempfile.mkstemp(suffix=".json", prefix="dativo_hook_")
+    try:
+        with os.fdopen(fd, "w") as f:
+            json.dump(payload, f, indent=2)
+        return Path(payload_path)
+    except Exception:
+        os.close(fd)
+        raise
 
-    def __init__(
-        self,
-        command: List[str],
-        user_env: Optional[Dict[str, str]] = None,
-        timeout_seconds: int = 15,
-    ):
-        """Initialize hook executor.
 
-        Args:
-            command: Command to execute as argv array
-            user_env: User-provided environment variables (supports ${VAR} expansion)
-            timeout_seconds: Timeout for hook execution
-        """
-        self.command = command
-        self.user_env = user_env or {}
-        self.timeout_seconds = timeout_seconds
-        self.logger = get_logger()
+def _execute_hook(
+    command: List[str],
+    payload_path: Path,
+    user_env: Optional[Dict[str, str]] = None,
+    timeout_seconds: int = 15,
+    hook_name: str = "unknown",
+) -> Tuple[bool, Optional[str]]:
+    """Execute a notification hook command.
 
-    def _build_environment(
-        self,
-        tenant_id: str,
-        job_name: str,
-        run_id: str,
-        summary_path: str,
-    ) -> Dict[str, str]:
-        """Build environment for hook execution.
+    Hook execution follows these rules:
+    - Always fails gracefully (never raises exceptions)
+    - Logs structured warnings/errors with redacted secrets
+    - Does not affect job outcome
 
-        Environment precedence (highest to lowest):
-        1. Required DATIVO_* variables (always set, override user values)
-        2. User-provided env (after ${VAR} expansion)
-        3. Existing process environment
+    Args:
+        command: Command to execute as argv array (supports ${VAR} expansion)
+        payload_path: Path to JSON payload file
+        user_env: User-provided environment variables (supports ${VAR} expansion)
+        timeout_seconds: Timeout for hook execution
+        hook_name: Hook name for logging
 
-        Args:
-            tenant_id: Tenant identifier
-            job_name: Job name
-            run_id: Run identifier
-            summary_path: Absolute path to summary JSON file
+    Returns:
+        Tuple of (success: bool, error_message: Optional[str])
+    """
+    logger = get_logger()
 
-        Returns:
-            Complete environment dict for subprocess
-        """
-        # Start with existing process environment
-        env = os.environ.copy()
+    # Expand env vars in command arguments
+    expanded_command = _expand_command_args(command)
 
-        # Apply user-provided env (after expansion)
-        expanded_user_env = expand_hook_env(self.user_env)
-        env.update(expanded_user_env)
-
-        # Apply required DATIVO_* variables (highest precedence)
-        env["DATIVO_TENANT_ID"] = tenant_id
-        env["DATIVO_JOB_NAME"] = job_name
-        env["DATIVO_RUN_ID"] = run_id
-        env["DATIVO_SUMMARY_PATH"] = summary_path
-
-        return env
-
-    def execute(
-        self,
-        tenant_id: str,
-        job_name: str,
-        run_id: str,
-        summary_path: str,
-    ) -> Tuple[bool, Optional[str]]:
-        """Execute the notification hook.
-
-        Hook execution follows these rules:
-        - Always fails gracefully (never raises exceptions)
-        - Logs structured warnings/errors with redacted secrets
-        - Does not affect job outcome
-
-        Args:
-            tenant_id: Tenant identifier
-            job_name: Job name
-            run_id: Run identifier
-            summary_path: Absolute path to summary JSON file
-
-        Returns:
-            Tuple of (success: bool, error_message: Optional[str])
-        """
-        # Validate command exists and is executable
-        command_path = Path(self.command[0])
-        if not command_path.exists():
-            error_msg = f"Hook command not found: {self.command[0]}"
-            self.logger.error(
-                error_msg,
-                extra={
-                    "event_type": "notification_hook_error",
-                    "error_type": "CommandNotFound",
-                    "command": self.command[0],
-                    "tenant_id": tenant_id,
-                    "job_name": job_name,
-                },
-            )
-            return False, error_msg
-
-        if not os.access(self.command[0], os.X_OK):
-            error_msg = f"Hook command not executable: {self.command[0]}"
-            self.logger.error(
-                error_msg,
-                extra={
-                    "event_type": "notification_hook_error",
-                    "error_type": "PermissionDenied",
-                    "command": self.command[0],
-                    "tenant_id": tenant_id,
-                    "job_name": job_name,
-                },
-            )
-            return False, error_msg
-
-        # Build environment
-        env = self._build_environment(tenant_id, job_name, run_id, summary_path)
-
-        # Log execution start (with redacted env)
-        redacted_user_env = _redact_env_for_logging(self.user_env)
-        self.logger.info(
-            f"Executing notification hook: {self.command[0]}",
+    # Validate command exists and is executable
+    if not Path(expanded_command[0]).exists():
+        error_msg = f"Hook command not found: {expanded_command[0]}"
+        logger.error(
+            error_msg,
             extra={
-                "event_type": "notification_hook_started",
-                "command": self.command,
-                "timeout_seconds": self.timeout_seconds,
-                "user_env": redacted_user_env,
-                "tenant_id": tenant_id,
-                "job_name": job_name,
-                "run_id": run_id,
+                "event_type": "notification_hook_error",
+                "error_type": "CommandNotFound",
+                "hook_name": hook_name,
+                "command": expanded_command[0],
             },
         )
+        return False, error_msg
 
-        try:
-            # Execute command with timeout
-            result = subprocess.run(
-                self.command,
-                env=env,
-                capture_output=True,
-                text=True,
-                timeout=self.timeout_seconds,
-            )
+    if not os.access(expanded_command[0], os.X_OK):
+        error_msg = f"Hook command not executable: {expanded_command[0]}"
+        logger.error(
+            error_msg,
+            extra={
+                "event_type": "notification_hook_error",
+                "error_type": "PermissionDenied",
+                "hook_name": hook_name,
+                "command": expanded_command[0],
+            },
+        )
+        return False, error_msg
 
-            if result.returncode == 0:
-                self.logger.info(
-                    "Notification hook executed successfully",
-                    extra={
-                        "event_type": "notification_hook_success",
-                        "command": self.command[0],
-                        "tenant_id": tenant_id,
-                        "job_name": job_name,
-                        "run_id": run_id,
-                    },
-                )
-                return True, None
-            else:
-                # Non-zero exit - log warning but don't fail
-                stderr_snippet = (
-                    result.stderr[:500] if result.stderr else "(no stderr)"
-                )
-                # Redact potential secrets in stderr
-                for pattern in SECRET_PATTERNS:
-                    stderr_snippet = pattern.sub("[REDACTED]", stderr_snippet)
+    # Build environment
+    env = os.environ.copy()
+    expanded_user_env = expand_hook_env(user_env)
+    env.update(expanded_user_env)
+    env["DATIVO_HOOK_PAYLOAD"] = str(payload_path.absolute())
 
-                error_msg = f"Hook exited with code {result.returncode}"
-                self.logger.warning(
-                    error_msg,
-                    extra={
-                        "event_type": "notification_hook_failed",
-                        "command": self.command[0],
-                        "exit_code": result.returncode,
-                        "stderr_snippet": stderr_snippet,
-                        "tenant_id": tenant_id,
-                        "job_name": job_name,
-                        "run_id": run_id,
-                    },
-                )
-                return False, f"{error_msg}: {stderr_snippet}"
+    # Log execution start (with redacted command and env)
+    redacted_command = _redact_command_args(expanded_command)
+    redacted_user_env = _redact_env_for_logging(user_env or {})
+    logger.info(
+        f"Executing notification hook: {hook_name}",
+        extra={
+            "event_type": "notification_hook_started",
+            "hook_name": hook_name,
+            "command": redacted_command,
+            "timeout_seconds": timeout_seconds,
+            "user_env": redacted_user_env,
+        },
+    )
 
-        except subprocess.TimeoutExpired:
-            error_msg = f"Hook timed out after {self.timeout_seconds}s"
-            self.logger.warning(
-                error_msg,
+    try:
+        # Execute command with timeout
+        result = subprocess.run(
+            expanded_command,
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=timeout_seconds,
+        )
+
+        if result.returncode == 0:
+            logger.info(
+                "Notification hook executed successfully",
                 extra={
-                    "event_type": "notification_hook_timeout",
-                    "command": self.command[0],
-                    "timeout_seconds": self.timeout_seconds,
-                    "tenant_id": tenant_id,
-                    "job_name": job_name,
-                    "run_id": run_id,
+                    "event_type": "notification_hook_success",
+                    "hook_name": hook_name,
                 },
             )
-            return False, error_msg
+            return True, None
+        else:
+            # Non-zero exit - log warning but don't fail
+            stderr_snippet = result.stderr[:500] if result.stderr else "(no stderr)"
+            # Redact potential secrets in stderr
+            for pattern in SECRET_PATTERNS:
+                stderr_snippet = pattern.sub("[REDACTED]", stderr_snippet)
 
-        except Exception as e:
-            error_msg = f"Hook execution error: {type(e).__name__}: {str(e)}"
-            self.logger.error(
+            error_msg = f"Hook exited with code {result.returncode}"
+            logger.warning(
                 error_msg,
                 extra={
-                    "event_type": "notification_hook_error",
-                    "error_type": type(e).__name__,
-                    "command": self.command[0],
-                    "tenant_id": tenant_id,
-                    "job_name": job_name,
-                    "run_id": run_id,
+                    "event_type": "notification_hook_failed",
+                    "hook_name": hook_name,
+                    "exit_code": result.returncode,
+                    "stderr_snippet": stderr_snippet,
                 },
             )
-            return False, error_msg
+            return False, f"{error_msg}: {stderr_snippet}"
+
+    except subprocess.TimeoutExpired:
+        error_msg = f"Hook timed out after {timeout_seconds}s"
+        logger.warning(
+            error_msg,
+            extra={
+                "event_type": "notification_hook_timeout",
+                "hook_name": hook_name,
+                "timeout_seconds": timeout_seconds,
+            },
+        )
+        return False, error_msg
+
+    except Exception as e:
+        error_msg = f"Hook execution error: {type(e).__name__}: {str(e)}"
+        logger.error(
+            error_msg,
+            extra={
+                "event_type": "notification_hook_error",
+                "error_type": type(e).__name__,
+                "hook_name": hook_name,
+            },
+        )
+        return False, error_msg
 
 
 def execute_failure_notification(
     config: "NotificationsConfig",
     tenant_id: str,
     job_name: str,
-    run_id: str,
     config_path: str,
-    error_message: str,
-    error_type: str = "UnknownError",
-    summary_base_dir: str = "/logs/runs",
+    exit_code: int,
+    failure_reason: str,
+    summary_path: Optional[str] = None,
 ) -> bool:
     """Execute failure notification hook if configured.
 
     This is the main entry point for triggering notification hooks.
-    It handles the complete flow:
-    1. Writes failure summary to file
-    2. Executes the configured hook command
-    3. Returns success/failure status
+    Hooks execute only when exit_code is 2 (hard failure).
 
     Args:
         config: NotificationsConfig from runner config
         tenant_id: Tenant identifier
         job_name: Job/schedule name
-        run_id: Unique run identifier
         config_path: Path to job configuration file
-        error_message: Human-readable error message
-        error_type: Error type classification
-        summary_base_dir: Base directory for summary files
+        exit_code: Job exit code (must be 2 to trigger hooks)
+        failure_reason: Human-readable failure reason
+        summary_path: Optional path to run summary file
 
     Returns:
-        True if hook executed successfully, False otherwise
+        True if hook executed successfully or not configured, False on hook error
     """
-    # Import here to avoid circular imports
-    from .config import NotificationsConfig
-
     logger = get_logger()
 
     # Check if notifications are configured
     if not config or not config.on_failure:
-        logger.debug(
-            "No failure notification hook configured",
-            extra={
-                "event_type": "notification_hook_skipped",
-                "reason": "not_configured",
-                "tenant_id": tenant_id,
-                "job_name": job_name,
-            },
-        )
         return True  # Not an error - just not configured
+
+    # Only execute on exit_code 2 (hard failure)
+    if exit_code != 2:
+        return True
 
     on_failure = config.on_failure
 
-    # Generate failure summary
-    summary = FailureSummary(
-        tenant_id=tenant_id,
-        job_name=job_name,
-        run_id=run_id,
-        config_path=config_path,
-        error_message=error_message,
-        error_type=error_type,
-    )
-
-    # Write summary to file
+    # Create hook payload file
+    payload_path = None
     try:
-        summary_path = summary.write_to_file(base_dir=summary_base_dir)
-        logger.info(
-            f"Failure summary written to {summary_path}",
-            extra={
-                "event_type": "failure_summary_written",
-                "summary_path": str(summary_path),
-                "tenant_id": tenant_id,
-                "job_name": job_name,
-                "run_id": run_id,
-            },
+        payload_path = _create_hook_payload(
+            tenant_id=tenant_id,
+            job_name=job_name,
+            config_path=config_path,
+            exit_code=exit_code,
+            failure_reason=failure_reason,
+            summary_path=summary_path,
         )
+
+        # Execute hook
+        success, error = _execute_hook(
+            command=on_failure.command,
+            payload_path=payload_path,
+            user_env=on_failure.env,
+            timeout_seconds=on_failure.timeout_seconds,
+            hook_name="on_failure",
+        )
+
+        return success
+
     except Exception as e:
         logger.error(
-            f"Failed to write failure summary: {e}",
+            f"Failed to execute notification hook: {e}",
             extra={
-                "event_type": "failure_summary_error",
+                "event_type": "notification_hook_error",
                 "error": str(e),
                 "tenant_id": tenant_id,
                 "job_name": job_name,
             },
         )
-        # Continue anyway - try to execute hook with empty summary path
-        summary_path = Path("")
+        return False
 
-    # Execute notification hook
-    executor = NotificationHookExecutor(
-        command=on_failure.command,
-        user_env=on_failure.env,
-        timeout_seconds=on_failure.timeout_seconds,
-    )
-
-    success, error = executor.execute(
-        tenant_id=tenant_id,
-        job_name=job_name,
-        run_id=run_id,
-        summary_path=str(summary_path.absolute()) if summary_path else "",
-    )
-
-    return success
+    finally:
+        # Clean up payload file
+        if payload_path and payload_path.exists():
+            try:
+                payload_path.unlink()
+            except Exception:
+                pass  # Best effort cleanup

--- a/src/dativo_ingest/notification_hooks.py
+++ b/src/dativo_ingest/notification_hooks.py
@@ -1,0 +1,518 @@
+"""Notification hooks for runner-level failure notifications.
+
+This module implements the notification hook system that executes external
+commands when jobs fail. It follows Dativo's philosophy:
+- Headless, config-only
+- No embedded services
+- No opinionated integrations in core logic
+
+Hooks are triggered only on job failure (exit_code = 2).
+"""
+
+import json
+import os
+import re
+import subprocess
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+from .logging import get_logger
+
+
+# Patterns for redacting sensitive values in logs
+SECRET_PATTERNS = [
+    re.compile(r"(TOKEN|KEY|SECRET|WEBHOOK|PASSWORD|CREDENTIAL)", re.IGNORECASE),
+]
+
+
+def _should_redact_key(key: str) -> bool:
+    """Check if an environment variable key should be redacted in logs.
+
+    Args:
+        key: Environment variable key name
+
+    Returns:
+        True if the key contains sensitive patterns
+    """
+    for pattern in SECRET_PATTERNS:
+        if pattern.search(key):
+            return True
+    return False
+
+
+def _redact_env_for_logging(env: Dict[str, str]) -> Dict[str, str]:
+    """Redact sensitive values from environment dict for logging.
+
+    Args:
+        env: Environment variables dict
+
+    Returns:
+        Dict with sensitive values redacted
+    """
+    redacted = {}
+    for key, value in env.items():
+        if _should_redact_key(key):
+            redacted[key] = "***REDACTED***"
+        else:
+            redacted[key] = value
+    return redacted
+
+
+def _expand_env_variable(value: str) -> str:
+    """Expand ${VAR} style environment variable references.
+
+    Args:
+        value: String potentially containing ${VAR} references
+
+    Returns:
+        String with environment variables expanded
+    """
+    pattern = re.compile(r"\$\{([^}]+)\}")
+
+    def replace(match: re.Match) -> str:
+        var_name = match.group(1)
+        return os.environ.get(var_name, "")
+
+    return pattern.sub(replace, value)
+
+
+def expand_hook_env(
+    user_env: Optional[Dict[str, str]],
+) -> Dict[str, str]:
+    """Expand environment variables in hook env configuration.
+
+    Performs ${VAR} expansion for all values in the user-provided env dict.
+
+    Args:
+        user_env: User-provided environment variables with ${VAR} syntax
+
+    Returns:
+        Dict with all ${VAR} references expanded
+    """
+    if not user_env:
+        return {}
+
+    expanded = {}
+    for key, value in user_env.items():
+        expanded[key] = _expand_env_variable(value)
+
+    return expanded
+
+
+class FailureSummary:
+    """Generates failure summary JSON for notification hooks.
+
+    The summary file contains minimal, stable information about the failed run.
+    It never includes secrets and follows a stable schema contract.
+    """
+
+    def __init__(
+        self,
+        tenant_id: str,
+        job_name: str,
+        run_id: str,
+        config_path: str,
+        error_message: str,
+        error_type: str = "UnknownError",
+        timestamp: Optional[datetime] = None,
+    ):
+        """Initialize failure summary.
+
+        Args:
+            tenant_id: Tenant identifier
+            job_name: Job/schedule name
+            run_id: Unique run identifier (timestamp-based)
+            config_path: Path to job configuration file
+            error_message: Human-readable error message
+            error_type: Error type classification
+            timestamp: Failure timestamp (defaults to now)
+        """
+        self.tenant_id = tenant_id
+        self.job_name = job_name
+        self.run_id = run_id
+        self.config_path = config_path
+        self.error_message = error_message
+        self.error_type = error_type
+        self.timestamp = timestamp or datetime.now(timezone.utc)
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert to dictionary representation.
+
+        Returns:
+            Dict with summary fields
+        """
+        return {
+            "tenant_id": self.tenant_id,
+            "job_name": self.job_name,
+            "run_id": self.run_id,
+            "status": "failure",
+            "timestamp": self.timestamp.isoformat(),
+            "config_path": self.config_path,
+            "error": {
+                "message": self.error_message,
+                "type": self.error_type,
+            },
+        }
+
+    def to_json(self, indent: int = 2) -> str:
+        """Convert to JSON string.
+
+        Args:
+            indent: JSON indentation level
+
+        Returns:
+            JSON string representation
+        """
+        return json.dumps(self.to_dict(), indent=indent)
+
+    def write_to_file(self, base_dir: str = "/logs/runs") -> Path:
+        """Write summary to a deterministic file path.
+
+        Creates directory structure if needed:
+        {base_dir}/{run_id}/summary.json
+
+        Args:
+            base_dir: Base directory for run logs
+
+        Returns:
+            Path to written summary file
+        """
+        # Use run_id for directory name (sanitize for filesystem)
+        run_dir_name = self.run_id.replace(":", "-").replace("/", "-")
+        summary_dir = Path(base_dir) / run_dir_name
+        summary_dir.mkdir(parents=True, exist_ok=True)
+
+        summary_path = summary_dir / "summary.json"
+        with open(summary_path, "w") as f:
+            f.write(self.to_json())
+
+        return summary_path
+
+
+class NotificationHookExecutor:
+    """Executes notification hooks for job failures.
+
+    This class handles:
+    - Command execution (argv-based, no shell)
+    - Environment variable injection
+    - Timeout handling
+    - Graceful failure (never crashes the runner)
+    - Secret redaction in logs
+    """
+
+    # Required DATIVO_* environment variables injected by runner
+    REQUIRED_ENV_VARS = [
+        "DATIVO_TENANT_ID",
+        "DATIVO_JOB_NAME",
+        "DATIVO_RUN_ID",
+        "DATIVO_SUMMARY_PATH",
+    ]
+
+    def __init__(
+        self,
+        command: List[str],
+        user_env: Optional[Dict[str, str]] = None,
+        timeout_seconds: int = 15,
+    ):
+        """Initialize hook executor.
+
+        Args:
+            command: Command to execute as argv array
+            user_env: User-provided environment variables (supports ${VAR} expansion)
+            timeout_seconds: Timeout for hook execution
+        """
+        self.command = command
+        self.user_env = user_env or {}
+        self.timeout_seconds = timeout_seconds
+        self.logger = get_logger()
+
+    def _build_environment(
+        self,
+        tenant_id: str,
+        job_name: str,
+        run_id: str,
+        summary_path: str,
+    ) -> Dict[str, str]:
+        """Build environment for hook execution.
+
+        Environment precedence (highest to lowest):
+        1. Required DATIVO_* variables (always set, override user values)
+        2. User-provided env (after ${VAR} expansion)
+        3. Existing process environment
+
+        Args:
+            tenant_id: Tenant identifier
+            job_name: Job name
+            run_id: Run identifier
+            summary_path: Absolute path to summary JSON file
+
+        Returns:
+            Complete environment dict for subprocess
+        """
+        # Start with existing process environment
+        env = os.environ.copy()
+
+        # Apply user-provided env (after expansion)
+        expanded_user_env = expand_hook_env(self.user_env)
+        env.update(expanded_user_env)
+
+        # Apply required DATIVO_* variables (highest precedence)
+        env["DATIVO_TENANT_ID"] = tenant_id
+        env["DATIVO_JOB_NAME"] = job_name
+        env["DATIVO_RUN_ID"] = run_id
+        env["DATIVO_SUMMARY_PATH"] = summary_path
+
+        return env
+
+    def execute(
+        self,
+        tenant_id: str,
+        job_name: str,
+        run_id: str,
+        summary_path: str,
+    ) -> Tuple[bool, Optional[str]]:
+        """Execute the notification hook.
+
+        Hook execution follows these rules:
+        - Always fails gracefully (never raises exceptions)
+        - Logs structured warnings/errors with redacted secrets
+        - Does not affect job outcome
+
+        Args:
+            tenant_id: Tenant identifier
+            job_name: Job name
+            run_id: Run identifier
+            summary_path: Absolute path to summary JSON file
+
+        Returns:
+            Tuple of (success: bool, error_message: Optional[str])
+        """
+        # Validate command exists and is executable
+        command_path = Path(self.command[0])
+        if not command_path.exists():
+            error_msg = f"Hook command not found: {self.command[0]}"
+            self.logger.error(
+                error_msg,
+                extra={
+                    "event_type": "notification_hook_error",
+                    "error_type": "CommandNotFound",
+                    "command": self.command[0],
+                    "tenant_id": tenant_id,
+                    "job_name": job_name,
+                },
+            )
+            return False, error_msg
+
+        if not os.access(self.command[0], os.X_OK):
+            error_msg = f"Hook command not executable: {self.command[0]}"
+            self.logger.error(
+                error_msg,
+                extra={
+                    "event_type": "notification_hook_error",
+                    "error_type": "PermissionDenied",
+                    "command": self.command[0],
+                    "tenant_id": tenant_id,
+                    "job_name": job_name,
+                },
+            )
+            return False, error_msg
+
+        # Build environment
+        env = self._build_environment(tenant_id, job_name, run_id, summary_path)
+
+        # Log execution start (with redacted env)
+        redacted_user_env = _redact_env_for_logging(self.user_env)
+        self.logger.info(
+            f"Executing notification hook: {self.command[0]}",
+            extra={
+                "event_type": "notification_hook_started",
+                "command": self.command,
+                "timeout_seconds": self.timeout_seconds,
+                "user_env": redacted_user_env,
+                "tenant_id": tenant_id,
+                "job_name": job_name,
+                "run_id": run_id,
+            },
+        )
+
+        try:
+            # Execute command with timeout
+            result = subprocess.run(
+                self.command,
+                env=env,
+                capture_output=True,
+                text=True,
+                timeout=self.timeout_seconds,
+            )
+
+            if result.returncode == 0:
+                self.logger.info(
+                    "Notification hook executed successfully",
+                    extra={
+                        "event_type": "notification_hook_success",
+                        "command": self.command[0],
+                        "tenant_id": tenant_id,
+                        "job_name": job_name,
+                        "run_id": run_id,
+                    },
+                )
+                return True, None
+            else:
+                # Non-zero exit - log warning but don't fail
+                stderr_snippet = (
+                    result.stderr[:500] if result.stderr else "(no stderr)"
+                )
+                # Redact potential secrets in stderr
+                for pattern in SECRET_PATTERNS:
+                    stderr_snippet = pattern.sub("[REDACTED]", stderr_snippet)
+
+                error_msg = f"Hook exited with code {result.returncode}"
+                self.logger.warning(
+                    error_msg,
+                    extra={
+                        "event_type": "notification_hook_failed",
+                        "command": self.command[0],
+                        "exit_code": result.returncode,
+                        "stderr_snippet": stderr_snippet,
+                        "tenant_id": tenant_id,
+                        "job_name": job_name,
+                        "run_id": run_id,
+                    },
+                )
+                return False, f"{error_msg}: {stderr_snippet}"
+
+        except subprocess.TimeoutExpired:
+            error_msg = f"Hook timed out after {self.timeout_seconds}s"
+            self.logger.warning(
+                error_msg,
+                extra={
+                    "event_type": "notification_hook_timeout",
+                    "command": self.command[0],
+                    "timeout_seconds": self.timeout_seconds,
+                    "tenant_id": tenant_id,
+                    "job_name": job_name,
+                    "run_id": run_id,
+                },
+            )
+            return False, error_msg
+
+        except Exception as e:
+            error_msg = f"Hook execution error: {type(e).__name__}: {str(e)}"
+            self.logger.error(
+                error_msg,
+                extra={
+                    "event_type": "notification_hook_error",
+                    "error_type": type(e).__name__,
+                    "command": self.command[0],
+                    "tenant_id": tenant_id,
+                    "job_name": job_name,
+                    "run_id": run_id,
+                },
+            )
+            return False, error_msg
+
+
+def execute_failure_notification(
+    config: "NotificationsConfig",
+    tenant_id: str,
+    job_name: str,
+    run_id: str,
+    config_path: str,
+    error_message: str,
+    error_type: str = "UnknownError",
+    summary_base_dir: str = "/logs/runs",
+) -> bool:
+    """Execute failure notification hook if configured.
+
+    This is the main entry point for triggering notification hooks.
+    It handles the complete flow:
+    1. Writes failure summary to file
+    2. Executes the configured hook command
+    3. Returns success/failure status
+
+    Args:
+        config: NotificationsConfig from runner config
+        tenant_id: Tenant identifier
+        job_name: Job/schedule name
+        run_id: Unique run identifier
+        config_path: Path to job configuration file
+        error_message: Human-readable error message
+        error_type: Error type classification
+        summary_base_dir: Base directory for summary files
+
+    Returns:
+        True if hook executed successfully, False otherwise
+    """
+    # Import here to avoid circular imports
+    from .config import NotificationsConfig
+
+    logger = get_logger()
+
+    # Check if notifications are configured
+    if not config or not config.on_failure:
+        logger.debug(
+            "No failure notification hook configured",
+            extra={
+                "event_type": "notification_hook_skipped",
+                "reason": "not_configured",
+                "tenant_id": tenant_id,
+                "job_name": job_name,
+            },
+        )
+        return True  # Not an error - just not configured
+
+    on_failure = config.on_failure
+
+    # Generate failure summary
+    summary = FailureSummary(
+        tenant_id=tenant_id,
+        job_name=job_name,
+        run_id=run_id,
+        config_path=config_path,
+        error_message=error_message,
+        error_type=error_type,
+    )
+
+    # Write summary to file
+    try:
+        summary_path = summary.write_to_file(base_dir=summary_base_dir)
+        logger.info(
+            f"Failure summary written to {summary_path}",
+            extra={
+                "event_type": "failure_summary_written",
+                "summary_path": str(summary_path),
+                "tenant_id": tenant_id,
+                "job_name": job_name,
+                "run_id": run_id,
+            },
+        )
+    except Exception as e:
+        logger.error(
+            f"Failed to write failure summary: {e}",
+            extra={
+                "event_type": "failure_summary_error",
+                "error": str(e),
+                "tenant_id": tenant_id,
+                "job_name": job_name,
+            },
+        )
+        # Continue anyway - try to execute hook with empty summary path
+        summary_path = Path("")
+
+    # Execute notification hook
+    executor = NotificationHookExecutor(
+        command=on_failure.command,
+        user_env=on_failure.env,
+        timeout_seconds=on_failure.timeout_seconds,
+    )
+
+    success, error = executor.execute(
+        tenant_id=tenant_id,
+        job_name=job_name,
+        run_id=run_id,
+        summary_path=str(summary_path.absolute()) if summary_path else "",
+    )
+
+    return success

--- a/src/dativo_ingest/orchestrated.py
+++ b/src/dativo_ingest/orchestrated.py
@@ -158,16 +158,15 @@ def _execute_job_with_retry(
 
     # Trigger failure notification hook if configured (only for exit_code = 2)
     if last_exit_code == 2 and notifications_config:
-        run_id = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
-        error_message = last_error[:500] if last_error else "Unknown error"
+        failure_reason = last_error[:500] if last_error else "Unknown error"
         execute_failure_notification(
             config=notifications_config,
             tenant_id=tenant_id,
             job_name=schedule_config.name,
-            run_id=run_id,
             config_path=schedule_config.config,
-            error_message=error_message,
-            error_type="JobExecutionError",
+            exit_code=last_exit_code,
+            failure_reason=failure_reason,
+            summary_path=None,  # Summary path not available in orchestrated mode
         )
 
     raise Exception(
@@ -271,7 +270,10 @@ def create_dagster_assets(runner_config: RunnerConfig) -> Definitions:
 
                 # Execute job with retry logic
                 result = _execute_job_with_retry(
-                    schedule_config, job_config, custom_retry_policy, notifications_config
+                    schedule_config,
+                    job_config,
+                    custom_retry_policy,
+                    notifications_config,
                 )
 
                 # Calculate execution time

--- a/src/dativo_ingest/orchestrated.py
+++ b/src/dativo_ingest/orchestrated.py
@@ -4,6 +4,7 @@ import os
 import subprocess
 import sys
 import time
+from datetime import datetime, timezone
 from typing import Any, Dict, Optional
 
 from dagster import (
@@ -15,10 +16,11 @@ from dagster import (
     define_asset_job,
 )
 
-from .config import JobConfig, RunnerConfig
+from .config import JobConfig, NotificationsConfig, RunnerConfig
 from .logging import get_logger, setup_logging
 from .metrics_otel import configure_otel_metrics
 from .metrics_server import start_metrics_server_from_config
+from .notification_hooks import execute_failure_notification
 from .retry_policy import RetryPolicy as CustomRetryPolicy
 from .validator import ConnectorValidator
 
@@ -49,6 +51,7 @@ def _execute_job_with_retry(
     schedule_config: Any,
     job_config: JobConfig,
     custom_retry_policy: Optional[CustomRetryPolicy],
+    notifications_config: Optional[NotificationsConfig] = None,
 ) -> Dict[str, Any]:
     """Execute job with retry logic.
 
@@ -56,6 +59,7 @@ def _execute_job_with_retry(
         schedule_config: Schedule configuration
         job_config: Job configuration
         custom_retry_policy: Custom retry policy instance
+        notifications_config: Optional notifications configuration for failure hooks
 
     Returns:
         Job execution result
@@ -134,7 +138,9 @@ def _execute_job_with_retry(
                 custom_retry_policy.wait_for_retry(attempt)
                 attempt += 1
                 continue
-            raise
+            # Set exit code for notification
+            last_exit_code = 2
+            break
 
     # All retries exhausted or non-retryable error
     job_logger.error(
@@ -149,6 +155,21 @@ def _execute_job_with_retry(
             "stderr": last_error[:500] if last_error else None,
         },
     )
+
+    # Trigger failure notification hook if configured (only for exit_code = 2)
+    if last_exit_code == 2 and notifications_config:
+        run_id = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        error_message = last_error[:500] if last_error else "Unknown error"
+        execute_failure_notification(
+            config=notifications_config,
+            tenant_id=tenant_id,
+            job_name=schedule_config.name,
+            run_id=run_id,
+            config_path=schedule_config.config,
+            error_message=error_message,
+            error_type="JobExecutionError",
+        )
+
     raise Exception(
         f"Job execution failed after {attempt + 1} attempt(s): {last_error}"
     )
@@ -193,6 +214,9 @@ def create_dagster_assets(runner_config: RunnerConfig) -> Definitions:
 
             # Create Dagster retry policy
             dagster_retry_policy = _create_dagster_retry_policy(job_config)
+
+            # Get notifications config from runner (runner-level, not job-level)
+            notifications_config = runner_config.notifications
 
         except Exception as e:
             logger.error(
@@ -247,7 +271,7 @@ def create_dagster_assets(runner_config: RunnerConfig) -> Definitions:
 
                 # Execute job with retry logic
                 result = _execute_job_with_retry(
-                    schedule_config, job_config, custom_retry_policy
+                    schedule_config, job_config, custom_retry_policy, notifications_config
                 )
 
                 # Calculate execution time

--- a/tests/test_notification_hooks.py
+++ b/tests/test_notification_hooks.py
@@ -1,0 +1,279 @@
+"""Unit tests for notification hooks."""
+
+import json
+import os
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+import pytest
+
+# Add src to path for imports
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from dativo_ingest.config import NotificationsConfig, OnFailureHookConfig
+from dativo_ingest.notification_hooks import (
+    _expand_env_variable,
+    _redact_command_args,
+    _redact_env_for_logging,
+    execute_failure_notification,
+)
+
+
+def test_expand_env_variable():
+    """Test environment variable expansion."""
+    os.environ["TEST_VAR"] = "test_value"
+    os.environ["ANOTHER_VAR"] = "another_value"
+
+    # Simple expansion
+    assert _expand_env_variable("${TEST_VAR}") == "test_value"
+    assert (
+        _expand_env_variable("prefix-${TEST_VAR}-suffix") == "prefix-test_value-suffix"
+    )
+
+    # Multiple expansions
+    assert (
+        _expand_env_variable("${TEST_VAR}-${ANOTHER_VAR}") == "test_value-another_value"
+    )
+
+    # Default value
+    assert _expand_env_variable("${MISSING_VAR:-default}") == "default"
+    assert _expand_env_variable("${TEST_VAR:-default}") == "test_value"
+
+    # No expansion
+    assert _expand_env_variable("no-vars-here") == "no-vars-here"
+
+
+def test_redact_command_args():
+    """Test secret redaction in command arguments."""
+    args = ["script.sh", "--token=secret123", "--key=abc", "--normal=value"]
+    redacted = _redact_command_args(args)
+    assert redacted[0] == "script.sh"
+    assert redacted[1] == "--token=[REDACTED]"
+    assert redacted[2] == "--key=[REDACTED]"
+    assert redacted[3] == "--normal=value"
+
+
+def test_redact_env_for_logging():
+    """Test secret redaction in environment variables."""
+    env = {
+        "API_TOKEN": "secret123",
+        "NORMAL_VAR": "value",
+        "SECRET_KEY": "key123",
+    }
+    redacted = _redact_env_for_logging(env)
+    assert redacted["API_TOKEN"] == "***REDACTED***"
+    assert redacted["NORMAL_VAR"] == "value"
+    assert redacted["SECRET_KEY"] == "***REDACTED***"
+
+
+def test_hook_executes_only_on_exit_code_2(tmp_path, monkeypatch):
+    """Test that hooks execute only when exit_code is 2."""
+    # Create a test script that writes to a file
+    script_path = tmp_path / "test_hook.sh"
+    script_path.write_text("#!/bin/sh\necho 'hook executed' > /tmp/hook_output.txt\n")
+    script_path.chmod(0o755)
+
+    hook_config = OnFailureHookConfig(
+        command=["/bin/sh", str(script_path)],
+        timeout_seconds=15,
+    )
+    notifications_config = NotificationsConfig(on_failure=hook_config)
+
+    # Should not execute for exit_code 0
+    execute_failure_notification(
+        config=notifications_config,
+        tenant_id="test_tenant",
+        job_name="test_job",
+        config_path="test.yaml",
+        exit_code=0,
+        failure_reason="Test",
+    )
+    # Script should not have executed
+    output_file = Path("/tmp/hook_output.txt")
+    if output_file.exists():
+        output_file.unlink()
+
+    # Should execute for exit_code 2
+    execute_failure_notification(
+        config=notifications_config,
+        tenant_id="test_tenant",
+        job_name="test_job",
+        config_path="test.yaml",
+        exit_code=2,
+        failure_reason="Test failure",
+    )
+    # Script should have executed
+    if output_file.exists():
+        assert "hook executed" in output_file.read_text()
+        output_file.unlink()
+
+
+def test_hook_timeout(tmp_path):
+    """Test that hooks are killed after timeout."""
+    # Create a script that sleeps longer than timeout
+    script_path = tmp_path / "slow_hook.sh"
+    script_path.write_text("#!/bin/sh\nsleep 10\necho 'should not reach here'\n")
+    script_path.chmod(0o755)
+
+    hook_config = OnFailureHookConfig(
+        command=["/bin/sh", str(script_path)],
+        timeout_seconds=1,
+    )
+    notifications_config = NotificationsConfig(on_failure=hook_config)
+
+    start_time = time.time()
+    execute_failure_notification(
+        config=notifications_config,
+        tenant_id="test_tenant",
+        job_name="test_job",
+        config_path="test.yaml",
+        exit_code=2,
+        failure_reason="Test",
+    )
+    elapsed = time.time() - start_time
+
+    # Should have timed out quickly (within 2 seconds, accounting for overhead)
+    assert elapsed < 2.5
+
+
+def test_hook_env_expansion_and_redaction(tmp_path, monkeypatch):
+    """Test that environment variable expansion works and secrets are redacted."""
+    monkeypatch.setenv("HOOK_TOKEN", "secret_token_123")
+    monkeypatch.setenv("HOOK_URL", "https://example.com")
+
+    # Create a script that reads env vars and writes to file
+    script_path = tmp_path / "env_hook.sh"
+    output_file = tmp_path / "hook_output.txt"
+    script_path.write_text(
+        f"#!/bin/sh\n"
+        f'echo "TOKEN=$HOOK_TOKEN" > {output_file}\n'
+        f'echo "URL=$HOOK_URL" >> {output_file}\n'
+        f'echo "PAYLOAD=$DATIVO_HOOK_PAYLOAD" >> {output_file}\n'
+    )
+    script_path.chmod(0o755)
+
+    hook_config = OnFailureHookConfig(
+        command=["/bin/sh", str(script_path)],
+        env={
+            "HOOK_TOKEN": "${HOOK_TOKEN}",  # Should expand
+            "HOOK_URL": "${HOOK_URL}",  # Should expand
+            "CUSTOM_VAR": "custom_value",
+        },
+        timeout_seconds=15,
+    )
+    notifications_config = NotificationsConfig(on_failure=hook_config)
+
+    execute_failure_notification(
+        config=notifications_config,
+        tenant_id="test_tenant",
+        job_name="test_job",
+        config_path="test.yaml",
+        exit_code=2,
+        failure_reason="Test failure",
+    )
+
+    # Verify payload file was created and contains correct data
+    if output_file.exists():
+        output = output_file.read_text()
+        assert "TOKEN=secret_token_123" in output
+        assert "URL=https://example.com" in output
+        assert "PAYLOAD=" in output  # PAYLOAD env var should be set
+        assert ".json" in output  # Should contain path to JSON payload file
+
+
+def test_hook_payload_content(tmp_path):
+    """Test that hook payload contains correct information."""
+    script_path = tmp_path / "payload_test.sh"
+    payload_file = tmp_path / "captured_payload.json"
+
+    script_path.write_text(f"#!/bin/sh\n" f'cp "$DATIVO_HOOK_PAYLOAD" {payload_file}\n')
+    script_path.chmod(0o755)
+
+    hook_config = OnFailureHookConfig(
+        command=["/bin/sh", str(script_path)],
+        timeout_seconds=15,
+    )
+    notifications_config = NotificationsConfig(on_failure=hook_config)
+
+    execute_failure_notification(
+        config=notifications_config,
+        tenant_id="test_tenant",
+        job_name="test_job",
+        config_path="/path/to/config.yaml",
+        exit_code=2,
+        failure_reason="Test failure",
+        summary_path="/path/to/summary.json",
+    )
+
+    # Verify payload file was created and contains correct data
+    if payload_file.exists():
+        with open(payload_file) as f:
+            payload = json.load(f)
+        assert payload["tenant_id"] == "test_tenant"
+        assert payload["job_name"] == "test_job"
+        assert payload["config_path"] == "/path/to/config.yaml"
+        assert payload["exit_code"] == 2
+        assert payload["failure_reason"] == "Test failure"
+        assert payload["summary_path"] == "/path/to/summary.json"
+
+
+def test_hook_failure_does_not_crash(tmp_path):
+    """Test that hook failures don't crash the runner."""
+    # Create a script that exits with error
+    script_path = tmp_path / "failing_hook.sh"
+    script_path.write_text("#!/bin/sh\necho 'error' >&2\nexit 1\n")
+    script_path.chmod(0o755)
+
+    hook_config = OnFailureHookConfig(
+        command=["/bin/sh", str(script_path)],
+        timeout_seconds=15,
+    )
+    notifications_config = NotificationsConfig(on_failure=hook_config)
+
+    # Should not raise exception
+    result = execute_failure_notification(
+        config=notifications_config,
+        tenant_id="test_tenant",
+        job_name="test_job",
+        config_path="test.yaml",
+        exit_code=2,
+        failure_reason="Test",
+    )
+    # Should return False (hook failed) but not crash
+    assert result is False
+
+
+def test_hook_nonexistent_script_does_not_crash():
+    """Test that nonexistent scripts don't crash the runner."""
+    hook_config = OnFailureHookConfig(
+        command=["/nonexistent/script.sh"],
+        timeout_seconds=15,
+    )
+    notifications_config = NotificationsConfig(on_failure=hook_config)
+
+    # Should not raise exception
+    result = execute_failure_notification(
+        config=notifications_config,
+        tenant_id="test_tenant",
+        job_name="test_job",
+        config_path="test.yaml",
+        exit_code=2,
+        failure_reason="Test",
+    )
+    # Should return False (hook failed) but not crash
+    assert result is False
+
+
+def test_hook_no_config():
+    """Test that no config does nothing."""
+    result = execute_failure_notification(
+        config=None,
+        tenant_id="test_tenant",
+        job_name="test_job",
+        config_path="test.yaml",
+        exit_code=2,
+        failure_reason="Test",
+    )
+    assert result is True  # Not an error - just not configured


### PR DESCRIPTION
This pull request contains changes generated by a Cursor Cloud Agent

<a href="https://cursor.com/background-agent?bcId=bc-68ba1c92-7fa4-454f-b1a6-75c5fac21f08"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-68ba1c92-7fa4-454f-b1a6-75c5fac21f08"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces runner-level, failure-only notification hooks with external command execution and docs/examples.
> 
> - Core: New `notification_hooks` module writes per-run `summary.json` and executes `on_failure` commands with injected `DATIVO_*` env vars; secrets redacted, timeouts handled, failures are non-fatal
> - Config: Adds `NotificationsConfig`/`OnFailureHookConfig` to `RunnerConfig` (`runner.yaml` supports `notifications.on_failure` with `command`, `env`, `timeout_seconds`)
> - CLI: `run`/`ingest` accept `--runner-config`; on exit code `2` (non-dry-run), trigger hook with context; supports job-dir and single-file flows
> - Orchestrator: On final failure after retries, triggers the same failure hook for scheduled jobs
> - Docs & examples: Extensive docs for configuration/contract and shipped scripts `examples/scripts/notify_slack.sh` and `notify_webhook.sh`; sample `runner.yaml` commented block added
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b68833ca48aa33b23c095d89b9ab8f9a5ee4c29f. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->